### PR TITLE
Implement settings and dark mode features

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,27 +5,38 @@ import Login from './screens/Login';
 import Register from './screens/Register';
 import Activity from './screens/Activity';
 import Settings from './screens/Settings';
+import ChangePassword from './screens/ChangePassword';
 import MainTabs from './navigation/MainTabs';
 import { ThemeProvider } from './context/ThemeContext';
+import { EmojiProvider } from './context/EmojiContext';
+import { useUser } from './hooks/useUser';
 
 const Stack = createNativeStackNavigator();
 
 export default function App() {
+  const { user, loading } = useUser();
+  const initialRoute = user ? 'MainTabs' : 'Splash';
+
+  if (loading) return null;
+
   return (
     <ThemeProvider>
-      <NavigationContainer>
-        <Stack.Navigator
-          initialRouteName="Splash"
-          screenOptions={{ headerShown: false }}
-        >
-          <Stack.Screen name="Splash" component={Splash} />
-          <Stack.Screen name="Login" component={Login} />
-          <Stack.Screen name="Register" component={Register} />
-          <Stack.Screen name="MainTabs" component={MainTabs} />
-          <Stack.Screen name="Activity" component={Activity} />
-          <Stack.Screen name="Settings" component={Settings} />
-        </Stack.Navigator>
-      </NavigationContainer>
+      <EmojiProvider>
+        <NavigationContainer>
+          <Stack.Navigator
+            initialRouteName={initialRoute}
+            screenOptions={{ headerShown: false }}
+          >
+            <Stack.Screen name="Splash" component={Splash} />
+            <Stack.Screen name="Login" component={Login} />
+            <Stack.Screen name="Register" component={Register} />
+            <Stack.Screen name="MainTabs" component={MainTabs} />
+            <Stack.Screen name="Activity" component={Activity} />
+            <Stack.Screen name="Settings" component={Settings} />
+            <Stack.Screen name="ChangePassword" component={ChangePassword} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </EmojiProvider>
     </ThemeProvider>
   );
 }

--- a/components/ActivityRecord.tsx
+++ b/components/ActivityRecord.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
-import { theme } from '../constants/theme';
+import { useAppTheme } from '../hooks/useAppTheme';
+import { useTheme } from '../context/ThemeContext';
 import { useUser } from '../hooks/useUser';
 import { getActivitiesByUser } from '../services/activityService';
 
@@ -13,6 +14,8 @@ type Activity = {
 
 export default function Stats() {
   const { user, loading } = useUser();
+  const appTheme = useAppTheme();
+  const { theme } = useTheme();
   const [activities, setActivities] = useState<Activity[]>([]);
   const [loadingActivities, setLoadingActivities] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -36,29 +39,31 @@ export default function Stats() {
     fetchActivities();
   }, [user]);
 
+  const s = styles(appTheme, theme);
+
   if (loading || loadingActivities) {
     return (
-      <View style={styles.centered}>
+      <View style={s.centered}>
         <ActivityIndicator size="large" color="#333" />
-        <Text style={styles.info}>Cargando actividades...</Text>
+        <Text style={s.info}>Cargando actividades...</Text>
       </View>
     );
   }
 
-  if (!user) return <Text style={styles.info}>No estás logueado</Text>;
-  if (error) return <Text style={styles.info}>{error}</Text>;
-  if (activities.length === 0) return <Text style={styles.info}>No hay actividades registradas</Text>;
+  if (!user) return <Text style={s.info}>No estás logueado</Text>;
+  if (error) return <Text style={s.info}>{error}</Text>;
+  if (activities.length === 0) return <Text style={s.info}>No hay actividades registradas</Text>;
 
   return (
     <FlatList
       data={activities}
       keyExtractor={(item) => item.id}
       renderItem={({ item }) => (
-        <View style={styles.item}>
-          <Text style={styles.title}>{item.name || 'Actividad'}</Text>
-          <Text>Duración: {Math.round((item.duration || 0) / 60)} min</Text>
-          <Text>
-            Fecha:{' '}
+        <View style={s.item}>
+          <Text style={s.title}>{item.name || 'Actividad'}</Text>
+          <Text style={s.text}>Duración: {Math.round((item.duration || 0) / 60)} min</Text>
+          <Text style={s.text}>
+            Fecha{' '}
             {item.date?.seconds
               ? new Date(item.date.seconds * 1000).toLocaleString()
               : item.date
@@ -71,29 +76,33 @@ export default function Stats() {
   );
 }
 
-const styles = StyleSheet.create({
-  info: {
-    padding: 20,
-    textAlign: 'center',
-    fontSize: 16,
-    color: theme.colors.text,
-  },
+const styles = (appTheme: any, mode: string) =>
+  StyleSheet.create({
+    info: {
+      padding: 20,
+      textAlign: 'center',
+      fontSize: 16,
+      color: appTheme.colors.text,
+    },
   centered: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
-  item: {
-    backgroundColor: theme.colors.white,
-    padding: 16,
-    marginVertical: 8,
-    marginHorizontal: 16,
-    borderRadius: 10,
-    elevation: 2,
-  },
-  title: {
-    fontWeight: 'bold',
-    fontSize: 16,
-    marginBottom: 4,
-  },
-});
+    item: {
+      backgroundColor: mode === 'dark' ? '#1e1e1e' : appTheme.colors.white,
+      padding: 16,
+      marginVertical: 8,
+      marginHorizontal: 16,
+      borderRadius: 10,
+      borderWidth: mode === 'dark' ? 1 : 0,
+      borderColor: '#333',
+    },
+    title: {
+      fontWeight: 'bold',
+      fontSize: 16,
+      marginBottom: 4,
+      color: appTheme.colors.text,
+    },
+    text: { color: appTheme.colors.text },
+  });

--- a/components/activity/activityMap.tsx
+++ b/components/activity/activityMap.tsx
@@ -3,6 +3,9 @@ import { View, Text } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import type { LocationObjectCoords } from 'expo-location';
 import customMapStyle from '../../assets/mapStyle';
+import mapStyleDarkMode from '../../assets/mapStyleDarkMode';
+import { useTheme } from '../../context/ThemeContext';
+import { useEmoji } from '../../context/EmojiContext';
 
 type Props = {
   location: LocationObjectCoords;
@@ -23,6 +26,9 @@ export default function ActivityMap({
     console.time('MAP_LOAD');
   }, []);
 
+  const { theme } = useTheme();
+  const { emoji } = useEmoji();
+
   const handleMapReady = () => {
     console.timeEnd('MAP_LOAD');
     setMapReady(true);
@@ -30,7 +36,7 @@ export default function ActivityMap({
 
   return (
     <MapView
-      customMapStyle={customMapStyle}
+      customMapStyle={theme === 'dark' ? mapStyleDarkMode : customMapStyle}
       ref={mapRef}
       style={{ flex: 1 }}
       scrollEnabled={false}
@@ -58,7 +64,7 @@ export default function ActivityMap({
         }}
         anchor={{ x: 0.5, y: 0.5 }}
       >
-        <Text style={{ fontSize: 24 }}>🏃‍♂️</Text>
+        <Text style={{ fontSize: 24 }}>{emoji}</Text>
       </Marker>
     </MapView>
   );

--- a/context/EmojiContext.tsx
+++ b/context/EmojiContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+interface EmojiContextProps {
+  emoji: string;
+  setEmoji: (e: string) => void;
+}
+
+const EmojiContext = createContext<EmojiContextProps>({ emoji: '🏃‍♂️', setEmoji: () => {} });
+
+export const EmojiProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [emoji, setEmojiState] = useState('🏃‍♂️');
+
+  useEffect(() => {
+    const load = async () => {
+      const saved = await AsyncStorage.getItem('ACTIVITY_EMOJI');
+      if (saved) setEmojiState(saved);
+    };
+    load();
+  }, []);
+
+  const setEmoji = async (e: string) => {
+    setEmojiState(e);
+    await AsyncStorage.setItem('ACTIVITY_EMOJI', e);
+  };
+
+  return <EmojiContext.Provider value={{ emoji, setEmoji }}>{children}</EmojiContext.Provider>;
+};
+
+export const useEmoji = () => useContext(EmojiContext);

--- a/screens/Activity.tsx
+++ b/screens/Activity.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Vibration, Platform } from 'react-native';
+import { View, Vibration, Platform, SafeAreaView } from 'react-native';
 import MapView from 'react-native-maps';
 import NetInfo from '@react-native-community/netinfo';
 
@@ -89,7 +89,7 @@ const handleEndActivity = async () => {
   if (!location) return null;
 
   return (
-    <>
+    <SafeAreaView style={{ flex: 1 }}>
       <View style={{ flex: 1 }}>
         <ActivityMap
           location={location}
@@ -114,6 +114,6 @@ const handleEndActivity = async () => {
           onClose={() => setSummaryVisible(false)}
         />
       )}
-    </>
+    </SafeAreaView>
   );
 }

--- a/screens/ChangePassword.tsx
+++ b/screens/ChangePassword.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import {
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+  SafeAreaView,
+} from 'react-native';
+import {
+  getAuth,
+  EmailAuthProvider,
+  reauthenticateWithCredential,
+  updatePassword,
+} from 'firebase/auth';
+import { useAppTheme } from '../hooks/useAppTheme';
+import { useTheme } from '../context/ThemeContext';
+
+export default function ChangePassword({ navigation }: any) {
+  const [current, setCurrent] = useState('');
+  const [newPass, setNewPass] = useState('');
+  const [repeat, setRepeat] = useState('');
+  const [error, setError] = useState('');
+  const theme = useAppTheme();
+  const { theme: mode } = useTheme();
+  const styles = createStyles(theme, mode);
+
+  const handleSave = async () => {
+    setError('');
+    if (!current || !newPass || !repeat) {
+      setError('Completa todos los campos');
+      return;
+    }
+    if (newPass.length < 6) {
+      setError('La contraseña debe tener al menos 6 caracteres');
+      return;
+    }
+    if (newPass !== repeat) {
+      setError('Las contraseñas no coinciden');
+      return;
+    }
+    try {
+      const user = getAuth().currentUser;
+      if (!user || !user.email) throw new Error('Usuario no autenticado');
+      const cred = EmailAuthProvider.credential(user.email, current);
+      await reauthenticateWithCredential(user, cred);
+      await updatePassword(user, newPass);
+      Alert.alert('Éxito', 'Contraseña actualizada');
+      navigation.goBack();
+    } catch (e: any) {
+      setError(e.message || 'Error al actualizar');
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <TextInput
+        placeholder="Contraseña actual"
+        secureTextEntry
+        placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
+        style={styles.input}
+        value={current}
+        onChangeText={setCurrent}
+      />
+      <TextInput
+        placeholder="Nueva contraseña"
+        secureTextEntry
+        placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
+        style={styles.input}
+        value={newPass}
+        onChangeText={setNewPass}
+      />
+      <TextInput
+        placeholder="Repetir nueva contraseña"
+        secureTextEntry
+        placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
+        style={styles.input}
+        value={repeat}
+        onChangeText={setRepeat}
+      />
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <TouchableOpacity style={styles.button} onPress={handleSave}>
+        <Text style={styles.buttonText}>Guardar cambios</Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  );
+}
+
+const createStyles = (theme: any, mode: string) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      padding: 20,
+      backgroundColor: theme.colors.background,
+      justifyContent: 'center',
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: theme.colors.gray,
+      borderRadius: 6,
+      padding: 12,
+      marginBottom: 15,
+      color: mode === 'dark' ? '#fff' : '#000',
+      backgroundColor: mode === 'dark' ? '#1e1e1e' : theme.colors.white,
+    },
+    button: {
+      backgroundColor: theme.colors.primary,
+      padding: 15,
+      borderRadius: 6,
+      marginTop: 10,
+    },
+    buttonText: {
+      color: theme.colors.white,
+      textAlign: 'center',
+      fontWeight: 'bold',
+    },
+    error: { color: 'red', textAlign: 'center', marginBottom: 10 },
+  });

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
 import { useAppTheme } from '../hooks/useAppTheme';
 
 export default function Home({ navigation }: any) {
   const theme = useAppTheme();
   const styles = createStyles(theme);
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <Text style={styles.title}>VAMOS COMENÇAR?</Text>
 
       <TouchableOpacity
@@ -19,7 +19,7 @@ export default function Home({ navigation }: any) {
       <Text style={styles.subtitle}>
         presione o botao para iniciar uma nova atividade fisica
       </Text>
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/screens/Login.tsx
+++ b/screens/Login.tsx
@@ -1,48 +1,84 @@
-import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, TextInput, Alert } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, TextInput, Alert, ActivityIndicator, SafeAreaView } from 'react-native';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { loginWithEmail } from '../services/authService';
 import { useGoogleAuth } from '../firebase/googleAuth';
+import { useTheme } from '../context/ThemeContext';
+import { useUser } from '../hooks/useUser';
 
 export default function Login({ navigation }: any) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+  const [loading, setLoading] = useState(false);
   const { promptAsync } = useGoogleAuth();
   const theme = useAppTheme();
-  const styles = createStyles(theme);
+  const { theme: mode } = useTheme();
+  const { user } = useUser();
+  const styles = createStyles(theme, mode);
+
+  useEffect(() => {
+    if (user) {
+      navigation.reset({ index: 0, routes: [{ name: 'MainTabs' }] });
+    }
+  }, [user]);
 
   const handleLogin = async () => {
+    const emailRegex = /.+@.+\..+/;
+    let valid = true;
+    if (!emailRegex.test(email)) {
+      setEmailError('Formato de email inválido');
+      valid = false;
+    } else setEmailError('');
+    if (password.length < 6) {
+      setPasswordError('La contraseña debe tener al menos 6 caracteres');
+      valid = false;
+    } else setPasswordError('');
+    if (!valid) return;
+
     try {
+      setLoading(true);
       await loginWithEmail(email, password);
       navigation.replace('MainTabs');
     } catch (error: any) {
       Alert.alert('Error', error.message || 'No se pudo iniciar sesión');
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <Text style={styles.logo}>Saúde+</Text>
       <Text style={styles.subtitle}>Inicia sesión para comenzar</Text>
 
       <TextInput
         placeholder="Correo electrónico"
+        placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
         keyboardType="email-address"
         autoCapitalize="none"
         value={email}
         onChangeText={setEmail}
       />
+      {emailError ? <Text style={styles.error}>{emailError}</Text> : null}
       <TextInput
         placeholder="Contraseña"
+        placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
         secureTextEntry
         value={password}
         onChangeText={setPassword}
       />
+      {passwordError ? <Text style={styles.error}>{passwordError}</Text> : null}
 
-      <TouchableOpacity style={styles.loginButton} onPress={handleLogin}>
-        <Text style={styles.loginText}>Iniciar sesión</Text>
+      <TouchableOpacity style={styles.loginButton} onPress={handleLogin} disabled={loading}>
+        {loading ? (
+          <ActivityIndicator color={theme.colors.white} />
+        ) : (
+          <Text style={styles.loginText}>Iniciar sesión</Text>
+        )}
       </TouchableOpacity>
 
       <TouchableOpacity style={styles.googleButton} onPress={() => promptAsync()}>
@@ -52,11 +88,11 @@ export default function Login({ navigation }: any) {
       <TouchableOpacity onPress={() => navigation.navigate('Register')}>
         <Text style={styles.registerLink}>¿No tienes cuenta? Crear una</Text>
       </TouchableOpacity>
-    </View>
+    </SafeAreaView>
   );
 }
 
-const createStyles = (theme: any) =>
+const createStyles = (theme: any, mode: string) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -82,8 +118,10 @@ const createStyles = (theme: any) =>
       borderRadius: 6,
       padding: 12,
       marginBottom: 15,
-      backgroundColor: theme.colors.white,
+      backgroundColor: mode === 'dark' ? '#1e1e1e' : theme.colors.white,
+      color: mode === 'dark' ? '#fff' : '#000',
     },
+    error: { color: 'red', marginBottom: 10 },
     loginButton: {
       backgroundColor: theme.colors.primary,
       padding: 15,

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -1,19 +1,48 @@
 import { signOut } from 'firebase/auth';
 import { auth } from '../firebase/firebase';
-import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import {
+  View,
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  Modal,
+} from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { useNavigation } from '@react-navigation/native';
+import { useUser } from '../hooks/useUser';
+import { useEmoji } from '../context/EmojiContext';
 
 export default function Profile() {
   const navigation = useNavigation<any>();
+  const { user } = useUser();
+  const { emoji, setEmoji } = useEmoji();
   const theme = useAppTheme();
+  const [modalVisible, setModalVisible] = React.useState(false);
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      justifyContent: 'center',
+      padding: 20,
       alignItems: 'center',
       backgroundColor: theme.colors.background,
     },
+    header: {
+      width: '100%',
+      alignItems: 'flex-end',
+    },
+    avatar: {
+      width: 80,
+      height: 80,
+      borderRadius: 40,
+      backgroundColor: theme.colors.gray,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginVertical: 20,
+    },
+    name: { fontSize: 20, color: theme.colors.text, marginBottom: 4 },
+    email: { color: theme.colors.darkGray, marginBottom: 10 },
+    label: { color: theme.colors.text },
     logoutButton: {
       backgroundColor: theme.colors.primary,
       paddingVertical: 12,
@@ -21,23 +50,82 @@ export default function Profile() {
       borderRadius: 6,
     },
     logoutText: { color: theme.colors.white, fontWeight: 'bold' },
+    emojiButton: { marginTop: 20 },
+    emoji: { fontSize: 40 },
+    modalBg: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: 'rgba(0,0,0,0.5)',
+    },
+    modalContent: {
+      backgroundColor: theme.colors.background,
+      padding: 20,
+      borderRadius: 8,
+      flexDirection: 'row',
+    },
+    emojiOption: { marginHorizontal: 10 },
   });
 
   const handleLogout = async () => {
     try {
       await signOut(auth);
-      navigation.replace('Login'); // o navigation.navigate si preferís
+      navigation.replace('Login');
     } catch (error) {
       console.error('Error al cerrar sesión:', error);
     }
   };
 
+  const emojis = ['🏃‍♂️', '🚴‍♀️', '🏊‍♂️', '🤸‍♂️', '🏋️‍♂️'];
+
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.navigate('Settings')}>
+          <Ionicons name="settings-outline" size={24} color={theme.colors.text} />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.avatar}>
+        <Ionicons name="person" size={40} color={theme.colors.white} />
+      </View>
+      <Text style={styles.name}>{user?.displayName || 'Usuario'}</Text>
+      <Text style={styles.email}>{user?.email}</Text>
+
+      <TouchableOpacity
+        style={styles.emojiButton}
+        onPress={() => setModalVisible(true)}
+      >
+        <Text style={styles.label}>Elegir emoji de actividad: {emoji}</Text>
+      </TouchableOpacity>
+
       <TouchableOpacity onPress={handleLogout} style={styles.logoutButton}>
         <Text style={styles.logoutText}>Cerrar sesión</Text>
       </TouchableOpacity>
-    </View>
+
+      <Modal transparent visible={modalVisible} animationType="fade">
+        <TouchableOpacity
+          style={styles.modalBg}
+          activeOpacity={1}
+          onPress={() => setModalVisible(false)}
+        >
+          <View style={styles.modalContent}>
+            {emojis.map((e) => (
+              <TouchableOpacity
+                key={e}
+                style={styles.emojiOption}
+                onPress={() => {
+                  setEmoji(e);
+                  setModalVisible(false);
+                }}
+              >
+                <Text style={styles.emoji}>{e}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </TouchableOpacity>
+      </Modal>
+    </SafeAreaView>
   );
 }
 

--- a/screens/Register.tsx
+++ b/screens/Register.tsx
@@ -1,58 +1,94 @@
-import React, { useState } from 'react';
-import { View, Text, TextInput, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, Text, TextInput, StyleSheet, TouchableOpacity, Alert, ActivityIndicator, SafeAreaView } from 'react-native';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { registerWithEmail } from '../services/authService';
 import { useNavigation } from '@react-navigation/native';
+import { useTheme } from '../context/ThemeContext';
+import { useUser } from '../hooks/useUser';
 
 export default function Register() {
   const navigation = useNavigation();
   const theme = useAppTheme();
-  const styles = createStyles(theme);
+  const { theme: mode } = useTheme();
+  const { user } = useUser();
+  const styles = createStyles(theme, mode);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (user) {
+      navigation.reset({ index: 0, routes: [{ name: 'MainTabs' }] });
+    }
+  }, [user]);
 
   const handleRegister = async () => {
+    const emailRegex = /.+@.+\..+/;
+    let valid = true;
+    if (!emailRegex.test(email)) {
+      setEmailError('Formato de email inválido');
+      valid = false;
+    } else setEmailError('');
+    if (password.length < 6) {
+      setPasswordError('La contraseña debe tener al menos 6 caracteres');
+      valid = false;
+    } else setPasswordError('');
+    if (!valid) return;
+
     try {
+      setLoading(true);
       await registerWithEmail(email, password);
       Alert.alert('Cuenta creada', 'Ya podés iniciar sesión');
       navigation.goBack();
     } catch (error: any) {
       Alert.alert('Error', error.message || 'No se pudo crear la cuenta');
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <Text style={styles.title}>Crear cuenta</Text>
 
       <TextInput
         placeholder="Correo electrónico"
+        placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
         keyboardType="email-address"
         autoCapitalize="none"
         value={email}
         onChangeText={setEmail}
       />
+      {emailError ? <Text style={styles.error}>{emailError}</Text> : null}
       <TextInput
         placeholder="Contraseña"
+        placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
         secureTextEntry
         value={password}
         onChangeText={setPassword}
       />
+      {passwordError ? <Text style={styles.error}>{passwordError}</Text> : null}
 
-      <TouchableOpacity style={styles.button} onPress={handleRegister}>
-        <Text style={styles.buttonText}>Registrarse</Text>
+      <TouchableOpacity style={styles.button} onPress={handleRegister} disabled={loading}>
+        {loading ? (
+          <ActivityIndicator color={theme.colors.white} />
+        ) : (
+          <Text style={styles.buttonText}>Registrarse</Text>
+        )}
       </TouchableOpacity>
 
       <TouchableOpacity onPress={() => navigation.goBack()}>
         <Text style={styles.loginLink}>¿Ya tenés cuenta? Iniciar sesión</Text>
       </TouchableOpacity>
-    </View>
+    </SafeAreaView>
   );
 }
 
-const createStyles = (theme: any) =>
+const createStyles = (theme: any, mode: string) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -73,7 +109,8 @@ const createStyles = (theme: any) =>
       borderRadius: 6,
       padding: 12,
       marginBottom: 15,
-      backgroundColor: theme.colors.white,
+      backgroundColor: mode === 'dark' ? '#1e1e1e' : theme.colors.white,
+      color: mode === 'dark' ? '#fff' : '#000',
     },
     button: {
       backgroundColor: theme.colors.primary,
@@ -90,4 +127,5 @@ const createStyles = (theme: any) =>
       color: theme.colors.primary,
       marginTop: 20,
     },
+    error: { color: 'red', marginBottom: 10 },
   });

--- a/screens/Settings.tsx
+++ b/screens/Settings.tsx
@@ -1,25 +1,43 @@
 import React from 'react';
-import { View, Text, StyleSheet, Switch } from 'react-native';
+import { View, Text, StyleSheet, Switch, TouchableOpacity, SafeAreaView } from 'react-native';
 import { useTheme } from '../context/ThemeContext';
 import { useAppTheme } from '../hooks/useAppTheme';
+import { useNavigation } from '@react-navigation/native';
 
 export default function Settings() {
+  const navigation = useNavigation<any>();
   const { theme, toggleTheme } = useTheme();
   const appTheme = useAppTheme();
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      justifyContent: 'center',
-      alignItems: 'center',
+      padding: 20,
       backgroundColor: appTheme.colors.background,
     },
-    text: { color: appTheme.colors.text, marginBottom: 10 },
+    settingItem: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingVertical: 15,
+      borderBottomWidth: 1,
+      borderColor: appTheme.colors.gray,
+    },
+    label: { color: appTheme.colors.text, fontSize: 16 },
+    link: { color: appTheme.colors.primary, fontSize: 16 },
   });
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Dark Mode</Text>
-      <Switch value={theme === 'dark'} onValueChange={toggleTheme} />
-    </View>
+    <SafeAreaView style={styles.container}>
+      <View style={styles.settingItem}>
+        <Text style={styles.label}>Modo escuro</Text>
+        <Switch value={theme === 'dark'} onValueChange={toggleTheme} />
+      </View>
+      <TouchableOpacity
+        style={styles.settingItem}
+        onPress={() => navigation.navigate('ChangePassword')}
+      >
+        <Text style={styles.link}>Cambiar contraseña</Text>
+      </TouchableOpacity>
+    </SafeAreaView>
   );
 }

--- a/screens/Splash.tsx
+++ b/screens/Splash.tsx
@@ -1,15 +1,23 @@
-import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useEffect } from 'react';
+import { Text, StyleSheet, TouchableOpacity, SafeAreaView } from 'react-native';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { useNavigation } from '@react-navigation/native';
+import { useUser } from '../hooks/useUser';
 
 export default function SplashScreen() {
   const navigation = useNavigation<any>();
+  const { user } = useUser();
   const theme = useAppTheme();
   const styles = createStyles(theme);
 
+  useEffect(() => {
+    if (user) {
+      navigation.reset({ index: 0, routes: [{ name: 'MainTabs' }] });
+    }
+  }, [user]);
+
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <Text style={styles.title}>Saúde+</Text>
       <Text style={styles.subtitle}>Transforme passos em economia</Text>
 
@@ -28,7 +36,7 @@ export default function SplashScreen() {
       </TouchableOpacity>
 
       <Text style={styles.footer}>© 2025 Saúde+. Todos os direitos reservados.</Text>
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/screens/Stats.tsx
+++ b/screens/Stats.tsx
@@ -1,16 +1,32 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Text, TouchableOpacity, SafeAreaView } from 'react-native';
 import { useAppTheme } from '../hooks/useAppTheme';
 import ActivityRecord from '../components/ActivityRecord';
+import { useNavigation } from '@react-navigation/native';
+import Ionicons from '@expo/vector-icons/Ionicons';
 
 export default function Stats() {
+  const navigation = useNavigation<any>();
   const theme = useAppTheme();
   const styles = StyleSheet.create({
     container: { flex: 1, backgroundColor: theme.colors.background },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 15,
+    },
+    title: { flex: 1, textAlign: 'center', color: theme.colors.text, fontSize: 16, fontWeight: 'bold' },
   });
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
+        </TouchableOpacity>
+        <Text style={styles.title}>Registro de Atividades</Text>
+        <View style={{ width: 24 }} />
+      </View>
       <ActivityRecord />
-    </View>
+    </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary
- add emoji context for storing chosen activity emoji
- wire up auth-aware navigation in `App`
- create password change screen
- update settings with password option and dark mode toggle
- improve profile screen with user data and emoji selector
- style login and register for dark mode and add validation
- show selected emoji on the activity map and apply dark map style
- add dark themed activity cards and header to history screen
- update other screens to use SafeAreaView

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b0ee8d108322b8a73487267f2edd