### PR TITLE
Improve activity UI and navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import Splash from './screens/Splash';
 import Login from './screens/Login';
 import Register from './screens/Register';
 import Activity from './screens/Activity';
+import ActivityLoading from './screens/ActivityLoading';
 import Settings from './screens/Settings';
 import ChangePassword from './screens/ChangePassword';
 import MainTabs from './navigation/MainTabs';
@@ -25,12 +26,17 @@ export default function App() {
         <NavigationContainer>
           <Stack.Navigator
             initialRouteName={initialRoute}
-            screenOptions={{ headerShown: false }}
+            screenOptions={{
+              headerShown: false,
+              animation: 'fade_from_bottom',
+              gestureEnabled: true,
+            }}
           >
             <Stack.Screen name="Splash" component={Splash} />
             <Stack.Screen name="Login" component={Login} />
             <Stack.Screen name="Register" component={Register} />
             <Stack.Screen name="MainTabs" component={MainTabs} />
+            <Stack.Screen name="ActivityLoading" component={ActivityLoading} />
             <Stack.Screen name="Activity" component={Activity} />
             <Stack.Screen name="Settings" component={Settings} />
             <Stack.Screen name="ChangePassword" component={ChangePassword} />

--- a/components/activity/activityMap.tsx
+++ b/components/activity/activityMap.tsx
@@ -68,18 +68,7 @@ export default function ActivityMap({
           <Text style={{ fontSize: 32 }}>{emoji}</Text>
         </Marker>
       </MapView>
-      <View
-        pointerEvents="none"
-        style={{
-          position: 'absolute',
-          bottom: 4,
-          left: 4,
-          width: 80,
-          height: 20,
-          backgroundColor: theme === 'dark' ? '#1e1e1e' : '#f1f1f1',
-          zIndex: 999,
-        }}
-      />
+      {/* Placeholder to avoid Google logo overlap handled by footer */}
     </View>
   );
 }

--- a/components/activity/activityOverlay.tsx
+++ b/components/activity/activityOverlay.tsx
@@ -1,6 +1,14 @@
-import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Platform } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Platform,
+  Animated,
+} from 'react-native';
 import { useAppTheme } from '../../hooks/useAppTheme';
+import { useEmoji } from '../../context/EmojiContext';
 
 type Props = {
   distance: number;
@@ -11,55 +19,94 @@ type Props = {
 
 export default function ActivityOverlay({ distance, timeFormatted, onEnd, disabled }: Props) {
   const theme = useAppTheme();
+  const { emoji } = useEmoji();
+  const scale = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(scale, { toValue: 1.2, duration: 600, useNativeDriver: true }),
+        Animated.timing(scale, { toValue: 1, duration: 600, useNativeDriver: true }),
+      ])
+    ).start();
+  }, [scale]);
+
   const styles = createStyles(theme);
   return (
-    <View style={styles.overlay}>
-      <Text style={styles.distance}>{distance.toFixed(2)} km</Text>
-      <Text style={styles.time}>Duração: {timeFormatted}</Text>
-      <TouchableOpacity style={styles.button} onPress={onEnd} disabled={disabled}>
-        <Text style={styles.buttonText}>FINALIZAR</Text>
-      </TouchableOpacity>
-    </View>
+    <>
+      <View style={styles.header}>
+        <Animated.Text style={[styles.emoji, { transform: [{ scale }] }]}>{emoji}</Animated.Text>
+        <Text style={styles.distance}>{distance.toFixed(2)} km</Text>
+        <Text style={styles.time}>Duração: {timeFormatted}</Text>
+      </View>
+      <View style={styles.footer} pointerEvents="box-none">
+        <TouchableOpacity style={styles.button} onPress={onEnd} disabled={disabled}>
+          <Text style={styles.buttonText}>FINALIZAR</Text>
+        </TouchableOpacity>
+      </View>
+    </>
   );
 }
 
 const createStyles = (theme: any) =>
   StyleSheet.create({
-    overlay: {
+    header: {
       position: 'absolute',
       top: Platform.OS === 'ios' ? 60 : 40,
       alignSelf: 'center',
-      alignItems: 'center',
-      backgroundColor: 'rgba(0,0,0,0.5)',
+      paddingVertical: 10,
+      paddingHorizontal: 20,
+      backgroundColor: theme.colors.white === '#000000'
+        ? 'rgba(0,0,0,0.6)'
+        : 'rgba(255,255,255,0.9)',
       borderRadius: 12,
-      padding: 12,
-      zIndex: 2,
       shadowColor: '#000',
       shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.2,
+      shadowOpacity: 0.3,
       shadowRadius: 6,
-      elevation: 8,
+      elevation: 4,
+      alignItems: 'center',
+      zIndex: 2,
+    },
+    emoji: {
+      fontSize: 36,
     },
     distance: {
-      fontSize: 32,
-      color: theme.colors.white,
+      fontSize: 20,
       fontWeight: 'bold',
+      color: theme.colors.white === '#000000' ? '#fff' : '#000',
     },
     time: {
-      fontSize: 18,
-      color: theme.colors.white,
-      marginVertical: 5,
+      fontSize: 14,
+      color: theme.colors.white === '#000000' ? '#ccc' : '#555',
+    },
+    footer: {
+      position: 'absolute',
+      bottom: 20,
+      left: 0,
+      right: 0,
+      backgroundColor:
+        theme.colors.white === '#000000'
+          ? 'rgba(30,30,30,0.95)'
+          : 'rgba(255,255,255,0.85)',
+      borderTopLeftRadius: 16,
+      borderTopRightRadius: 16,
+      paddingVertical: 12,
+      paddingHorizontal: 24,
+      alignItems: 'center',
+      elevation: 6,
     },
     button: {
-      backgroundColor: theme.colors.primary,
-      borderRadius: 25,
-      paddingVertical: 10,
-      paddingHorizontal: 30,
-      marginTop: 16,
+      backgroundColor: '#00AEEF',
+      borderRadius: 32,
+      paddingVertical: 14,
+      paddingHorizontal: 32,
+      width: '100%',
+      alignItems: 'center',
     },
     buttonText: {
-      color: theme.colors.white,
-      fontSize: 18,
+      color: '#fff',
       fontWeight: 'bold',
+      fontSize: 16,
     },
   });

--- a/navigation/MainTabs.tsx
+++ b/navigation/MainTabs.tsx
@@ -15,6 +15,8 @@ export default function MainTabs() {
       screenOptions={({ route }) => ({
         headerShown: false,
         tabBarActiveTintColor: theme.colors.primary,
+        tabBarInactiveTintColor:
+          theme.colors.background === '#121212' ? '#aaa' : '#444',
         tabBarStyle: { backgroundColor: theme.colors.background },
         tabBarIcon: ({ color, size }) => {
           let icon = 'home';

--- a/screens/Activity.tsx
+++ b/screens/Activity.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { View, Vibration, Platform, SafeAreaView, TouchableOpacity, BackHandler, Modal, Text, Button } from 'react-native';
+import { View, Vibration, Platform, SafeAreaView, TouchableOpacity, BackHandler, Modal, Text, Button, StatusBar } from 'react-native';
 import MapView from 'react-native-maps';
 import NetInfo from '@react-native-community/netinfo';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -111,7 +111,14 @@ useFocusEffect(
   if (!location) return null;
 
   return (
-    <SafeAreaView style={{ flex: 1, paddingTop: 40 }}>
+    <SafeAreaView
+      style={{ flex: 1, backgroundColor: theme === 'dark' ? '#000' : '#fff' }}
+    >
+      <StatusBar
+        barStyle={theme === 'dark' ? 'light-content' : 'dark-content'}
+        backgroundColor="transparent"
+        translucent
+      />
       <TouchableOpacity
         onPress={handleExit}
         style={{
@@ -121,7 +128,11 @@ useFocusEffect(
           zIndex: 10,
         }}
       >
-        <Ionicons name="arrow-back" size={24} color="#fff" />
+        <Ionicons
+          name="arrow-back"
+          size={24}
+          color={theme === 'dark' ? '#fff' : '#000'}
+        />
       </TouchableOpacity>
       <View style={{ flex: 1 }}>
         <ActivityMap
@@ -193,15 +204,6 @@ useFocusEffect(
               Deseja encerrar ou salvar antes de sair?
             </Text>
             <View style={{ marginTop: 24 }}>
-              <Button
-                title="Encerrar sem salvar"
-                color="#e63946"
-                onPress={() => {
-                  stopTracking();
-                  setExitModalVisible(false);
-                  navigation.goBack();
-                }}
-              />
               <Button
                 title="Salvar e sair"
                 color="#1d3557"

--- a/screens/ActivityLoading.tsx
+++ b/screens/ActivityLoading.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useAppTheme } from '../hooks/useAppTheme';
+
+export default function ActivityLoading() {
+  const navigation = useNavigation<any>();
+  const theme = useAppTheme();
+  const styles = createStyles(theme);
+
+  useEffect(() => {
+    const timer = setTimeout(() => navigation.navigate('Activity'), 1500);
+    return () => clearTimeout(timer);
+  }, [navigation]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Preparando sua atividade...</Text>
+    </View>
+  );
+}
+
+const createStyles = (theme: any) =>
+  StyleSheet.create({
+    container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: theme.colors.background },
+    text: { fontSize: 18, color: theme.colors.text },
+  });

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -11,7 +11,7 @@ export default function Home({ navigation }: any) {
 
       <TouchableOpacity
         style={styles.playButton}
-        onPress={() => navigation.navigate('Activity')}
+        onPress={() => navigation.navigate('ActivityLoading')}
       >
         <Text style={styles.playIcon}>▶</Text>
       </TouchableOpacity>
@@ -30,8 +30,7 @@ const createStyles = (theme: any) =>
       backgroundColor: theme.colors.background,
       alignItems: 'center',
       justifyContent: 'center',
-      paddingHorizontal: 16,
-      paddingTop: 40,
+      paddingHorizontal: 24,
     },
     title: {
       fontSize: 32,


### PR DESCRIPTION
## Summary
- redesign activity overlay with floating header and bottom action button
- add status bar and dark mode tweaks in Activity screen
- remove discard option from exit modal
- center Home screen button and use loading transition screen
- tweak tab navigation colors
- create ActivityLoading screen for smooth transition
- update navigation stack with new screen
- clean up map component

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json` *(fails: expo tsconfig base not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c6e51354832284754829b3aa0e68