### PR TITLE
Fix transitions and dark mode

### DIFF
--- a/components/activity/activityOverlay.tsx
+++ b/components/activity/activityOverlay.tsx
@@ -82,7 +82,7 @@ const createStyles = (theme: any) =>
     },
     footer: {
       position: 'absolute',
-      bottom: 20,
+      bottom: 0,
       left: 0,
       right: 0,
       backgroundColor:
@@ -92,6 +92,7 @@ const createStyles = (theme: any) =>
       borderTopLeftRadius: 16,
       borderTopRightRadius: 16,
       paddingVertical: 12,
+      paddingBottom: 32,
       paddingHorizontal: 24,
       alignItems: 'center',
       elevation: 6,

--- a/components/activity/activitySummaryModal.tsx
+++ b/components/activity/activitySummaryModal.tsx
@@ -7,8 +7,10 @@ import {
   StyleSheet,
   View,
   Platform,
+  Button,
 } from 'react-native';
 import { useAppTheme } from '../../hooks/useAppTheme';
+import { useNavigation } from '@react-navigation/native';
 
 type Props = {
   visible: boolean;
@@ -19,6 +21,7 @@ type Props = {
 export default function ActivitySummaryModal({ visible, summary, onClose }: Props) {
   const theme = useAppTheme();
   const styles = createStyles(theme);
+  const navigation = useNavigation<any>();
   return (
     <Modal
       visible={visible}
@@ -34,6 +37,12 @@ export default function ActivitySummaryModal({ visible, summary, onClose }: Prop
             <TouchableOpacity style={styles.button} onPress={onClose}>
               <Text style={styles.buttonText}>FECHAR</Text>
             </TouchableOpacity>
+            <Button
+              title="Voltar ao início"
+              onPress={() =>
+                navigation.reset({ index: 0, routes: [{ name: 'Home' }] })
+              }
+            />
           </ScrollView>
         </View>
       </View>
@@ -49,10 +58,11 @@ const createStyles = (theme: any) =>
     justifyContent: 'center',
     paddingHorizontal: 20,
   },
-  modalContainer: {
-    backgroundColor: theme.colors.white,
-    borderRadius: 16,
-    padding: 20,
+    modalContainer: {
+      backgroundColor:
+        theme.colors.white === '#000000' ? '#1e1e1e' : '#fff',
+      borderRadius: 16,
+      padding: 20,
     elevation: 6,
     shadowColor: theme.colors.text,
     shadowOpacity: 0.25,
@@ -63,17 +73,19 @@ const createStyles = (theme: any) =>
   container: {
     alignItems: 'center',
   },
-  title: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 12,
-    textAlign: 'center',
-  },
-  text: {
-    fontFamily: Platform.select({ ios: 'Courier', android: 'monospace' }),
-    textAlign: 'center',
-    marginBottom: 20,
-  },
+    title: {
+      fontSize: 18,
+      fontWeight: 'bold',
+      marginBottom: 12,
+      textAlign: 'center',
+      color: theme.colors.white === '#000000' ? '#fff' : '#000',
+    },
+    text: {
+      fontFamily: Platform.select({ ios: 'Courier', android: 'monospace' }),
+      textAlign: 'center',
+      marginBottom: 20,
+      color: theme.colors.white === '#000000' ? '#ccc' : '#444',
+    },
   button: {
     backgroundColor: theme.colors.primary,
     borderRadius: 25,

--- a/screens/Activity.tsx
+++ b/screens/Activity.tsx
@@ -34,6 +34,15 @@ export default function Activity() {
   const [exitModalVisible, setExitModalVisible] = useState(false);
   const { theme } = useTheme();
 
+  const handleSaveAndExit = async () => {
+    await handleEndActivity();
+    setExitModalVisible(false);
+    navigation.reset({
+      index: 0,
+      routes: [{ name: 'Home' }],
+    });
+  };
+
 const handleEndActivity = async () => {
   if (activityEnded) return;
 
@@ -207,11 +216,7 @@ useFocusEffect(
               <Button
                 title="Salvar e sair"
                 color="#1d3557"
-                onPress={async () => {
-                  await handleEndActivity();
-                  setExitModalVisible(false);
-                  navigation.goBack();
-                }}
+                onPress={handleSaveAndExit}
               />
               <Button
                 title="Cancelar"

--- a/screens/ActivityLoading.tsx
+++ b/screens/ActivityLoading.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import MapView from 'react-native-maps';
 import { useNavigation } from '@react-navigation/native';
 import { useAppTheme } from '../hooks/useAppTheme';
 
@@ -7,15 +8,21 @@ export default function ActivityLoading() {
   const navigation = useNavigation<any>();
   const theme = useAppTheme();
   const styles = createStyles(theme);
+  const [isMapReady, setMapReady] = useState(false);
 
   useEffect(() => {
-    const timer = setTimeout(() => navigation.navigate('Activity'), 1500);
-    return () => clearTimeout(timer);
-  }, [navigation]);
+    if (isMapReady) {
+      navigation.replace('Activity');
+    }
+  }, [isMapReady, navigation]);
 
   return (
     <View style={styles.container}>
       <Text style={styles.text}>Preparando sua atividade...</Text>
+      <MapView
+        style={styles.hiddenMap}
+        onMapReady={() => setMapReady(true)}
+      />
     </View>
   );
 }
@@ -24,4 +31,5 @@ const createStyles = (theme: any) =>
   StyleSheet.create({
     container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: theme.colors.background },
     text: { fontSize: 18, color: theme.colors.text },
+    hiddenMap: { width: 1, height: 1, opacity: 0 },
   });


### PR DESCRIPTION
## Summary
- preload the map during ActivityLoading and navigate when ready
- allow exiting to Home cleanly after saving an activity
- make summary modal adapt to dark mode and reset navigation
- pin finish button to the very bottom of the screen

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866d0d6bafc8322ae855f62de03f5aa