### PR TITLE
Improve map loading UX

### DIFF
--- a/components/activity/activityMap.tsx
+++ b/components/activity/activityMap.tsx
@@ -10,16 +10,16 @@ import { useEmoji } from '../../context/EmojiContext';
 type Props = {
   location: LocationObjectCoords;
   route: LocationObjectCoords[];
-  mapLoaded: boolean;
-  setMapLoaded: (ready: boolean) => void;
+  mapReady: boolean;
+  setMapReady: (ready: boolean) => void;
   mapRef: React.RefObject<MapView | null>;
 };
 
 export default function ActivityMap({
   location,
   route,
-  mapLoaded,
-  setMapLoaded,
+  mapReady,
+  setMapReady,
   mapRef,
 }: Props) {
   useEffect(() => {
@@ -31,7 +31,7 @@ export default function ActivityMap({
 
   const handleMapReady = () => {
     console.timeEnd('MAP_LOAD');
-    setMapLoaded(true);
+    setMapReady(true);
   };
 
   return (

--- a/screens/Activity.tsx
+++ b/screens/Activity.tsx
@@ -39,7 +39,8 @@ export default function Activity() {
 
   const mapRef = useRef<MapView>(null);
   const navigation = useNavigation<any>();
-  const [mapLoaded, setMapLoaded] = useState(false);
+  const [mapReady, setMapReady] = useState(false);
+  const [locationReady, setLocationReady] = useState(false);
   const [summaryVisible, setSummaryVisible] = useState(false);
   const [activityEnded, setActivityEnded] = useState(false);
   const [activitySummary, setActivitySummary] = useState('');
@@ -114,6 +115,12 @@ useFocusEffect(
   }, []);
 
   useEffect(() => {
+    if (location) {
+      setLocationReady(true);
+    }
+  }, [location]);
+
+  useEffect(() => {
     if (Platform.OS === 'android') {
       try {
         // @ts-ignore
@@ -129,7 +136,25 @@ useFocusEffect(
     }
   }, []);
 
-  if (!location) return null;
+  if (!locationReady) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+          backgroundColor: theme === 'dark' ? '#000' : '#fff',
+        }}
+      >
+        <ActivityIndicator size="large" color="#00AEEF" />
+        <Text
+          style={{ marginTop: 10, color: theme === 'dark' ? '#eee' : '#333' }}
+        >
+          Carregando mapa...
+        </Text>
+      </View>
+    );
+  }
 
   return (
     <SafeAreaView
@@ -155,7 +180,7 @@ useFocusEffect(
           color={theme === 'dark' ? '#fff' : '#000'}
         />
       </TouchableOpacity>
-      {!mapLoaded && (
+      {!mapReady && (
         <View
           style={{
             position: 'absolute',
@@ -177,8 +202,8 @@ useFocusEffect(
         <ActivityMap
           location={location}
           route={route}
-          mapLoaded={mapLoaded}
-          setMapLoaded={setMapLoaded}
+          mapReady={mapReady}
+          setMapReady={setMapReady}
           mapRef={mapRef}
         />
 


### PR DESCRIPTION
## Summary
- handle loader logic correctly when waiting for map and location

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json` *(fails: expo base tsconfig missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866dd1383648322ac88a7f7ebf3dcd0