### PR TITLE
Fix offline duplicates & show pending count

### DIFF
--- a/hooks/useGlobalNetwork.ts
+++ b/hooks/useGlobalNetwork.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Alert } from 'react-native';
+import { logEvent } from '../utils/logger';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import NetInfo, { NetInfoStateType } from '@react-native-community/netinfo';
@@ -124,11 +124,11 @@ export default function useGlobalNetwork() {
       if (!connected) {
         wasOffline.current = true;
         reintentando.current = false;
-        Alert.alert('📴 Sin conexión');
         console.log('🚫 Sin conexión');
+        logEvent('NETWORK', 'Sin conexión');
       } else {
         if (wasOffline.current) {
-          Alert.alert('🔄 Conexión restablecida');
+          logEvent('NETWORK', 'Conexión restablecida');
           if (!reintentando.current) {
             reintentando.current = true;
             console.log('[GLOBAL NETWORK] Conexión restablecida: enviando pendientes');
@@ -146,7 +146,7 @@ export default function useGlobalNetwork() {
               : type === 'cellular'
               ? '📱 Usando datos móviles'
               : 'Tipo de conexión desconocido';
-          Alert.alert(msg);
+          logEvent('NETWORK', msg);
         }
         wasOffline.current = false;
       }

--- a/hooks/useNetworkListener.ts
+++ b/hooks/useNetworkListener.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Alert } from 'react-native';
+import { logEvent } from '../utils/logger';
 import NetInfo, { NetInfoStateType } from '@react-native-community/netinfo';
 
 export default function useNetworkListener() {
@@ -22,15 +22,11 @@ export default function useNetworkListener() {
 
       if (offline) {
         console.log('🚫 Sin conexión');
-        Alert.alert('🚫 Sin conexión', 'Conéctate a internet para continuar', [
-          { text: 'OK' },
-        ]);
+        logEvent('NETWORK', 'Sin conexión');
       } else {
         console.log('🔌 Conectado');
         if (prevType.current === 'none') {
-          Alert.alert('🔄 Conexión recuperada', 'Vuelves a estar en línea', [
-            { text: 'Genial' },
-          ]);
+          logEvent('NETWORK', 'Conexión recuperada');
         }
         if (
           prevType.current !== 'unknown' &&
@@ -38,7 +34,7 @@ export default function useNetworkListener() {
           prevType.current !== type
         ) {
           const msg = type === 'wifi' ? 'Usando WiFi' : 'Usando datos móviles';
-          Alert.alert('📶 Cambio de red', msg, [{ text: 'OK' }]);
+          logEvent('NETWORK', `Cambio de red: ${msg}`);
         }
       }
       prevType.current = offline ? 'none' : type;

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -8,7 +8,7 @@ import { usePendingActivities } from '../context/PendingActivitiesContext';
 
 export default function Home({ navigation }: any) {
   const theme = useAppTheme();
-  const { sync, logPending } = usePendingActivities();
+  const { sync, logPending, pendingCount } = usePendingActivities();
   const styles = createStyles(theme);
 
   useEffect(() => {
@@ -25,6 +25,11 @@ export default function Home({ navigation }: any) {
   }, []);
   return (
     <SafeAreaView style={styles.container}>
+      {pendingCount > 0 && (
+        <View style={styles.pendingBadge}>
+          <Text style={styles.pendingText}>{pendingCount}</Text>
+        </View>
+      )}
       <View style={styles.centerContent}>
         <Text style={styles.title}>VAMOS COMEÇAR?</Text>
         <TouchableOpacity
@@ -84,5 +89,21 @@ const createStyles = (theme: any) =>
       color: theme.colors.darkGray,
       textAlign: 'center',
       paddingHorizontal: 20,
+    },
+    pendingBadge: {
+      position: 'absolute',
+      top: 8,
+      right: 16,
+      backgroundColor: 'red',
+      borderRadius: 12,
+      minWidth: 24,
+      height: 24,
+      paddingHorizontal: 6,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    pendingText: {
+      color: '#fff',
+      fontWeight: 'bold',
     },
   });


### PR DESCRIPTION
## Summary
- replace Alert popups about network changes with log messages
- record network type when saving activities
- avoid duplicate entries in pending storage
- display pending activity count on the home screen

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -noEmit` *(fails: expo/tsconfig.base missing)*

------
https://chatgpt.com/codex/tasks/task_e_686822c87ffc8322bda527a6c6cc190c