### PR TITLE
Improve pending activity sync

### DIFF
--- a/context/PendingActivitiesContext.tsx
+++ b/context/PendingActivitiesContext.tsx
@@ -1,8 +1,15 @@
-import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import NetInfo from '@react-native-community/netinfo';
-import { getAuth } from 'firebase/auth';
+import { getAuth, onAuthStateChanged } from 'firebase/auth';
 import type { LocationObjectCoords } from 'expo-location';
 import { logEvent } from '../utils/logger';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export interface PendingActivity {
   distance: number;
@@ -21,6 +28,7 @@ interface PendingCtx {
 }
 
 const PendingActivityContext = createContext<PendingCtx | undefined>(undefined);
+const PENDING_KEY = 'PENDING_ACTIVITIES_V2';
 
 const sendToFirebase = async (activity: PendingActivity): Promise<void> => {
   const userId = getAuth().currentUser?.uid;
@@ -61,17 +69,28 @@ export const PendingActivityProvider: React.FC<{ children: React.ReactNode }> = 
         remaining.push(act);
       }
     }
-    setPending(remaining);
+    setPending(() => {
+      AsyncStorage.setItem(PENDING_KEY, JSON.stringify(remaining)).catch(() => undefined);
+      return remaining;
+    });
   };
 
   const add = (activity: PendingActivity) => {
-    setPending(prev => [...prev, activity]);
+    setPending(prev => {
+      const updated = [...prev, activity];
+      AsyncStorage.setItem(PENDING_KEY, JSON.stringify(updated)).catch(() => undefined);
+      return updated;
+    });
     logEvent('ACTIVITY_SAVED_LOCALLY', JSON.stringify(activity));
   };
 
   const logPending = () => {
     console.log(`\uD83D\uDC65 Pendientes: ${pending.length}`);
   };
+
+  useEffect(() => {
+    AsyncStorage.setItem(PENDING_KEY, JSON.stringify(pending)).catch(() => undefined);
+  }, [pending]);
 
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener(state => {
@@ -82,6 +101,29 @@ export const PendingActivityProvider: React.FC<{ children: React.ReactNode }> = 
       wasOffline.current = !online;
     });
     return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(getAuth(), async user => {
+      if (user) {
+        try {
+          const stored = await AsyncStorage.getItem(PENDING_KEY);
+          if (stored) {
+            setPending(JSON.parse(stored));
+          }
+          const state = await NetInfo.fetch();
+          const online = Boolean(state.isConnected) && state.isInternetReachable !== false;
+          if (online) {
+            await sync();
+          }
+        } catch {
+          // ignore parse errors
+        }
+      } else {
+        setPending([]);
+      }
+    });
+    return () => unsub();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- persist PendingActivities data in AsyncStorage
- reload activities on login and auto-sync if online

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686952c96d248322bda36b3a223e66bb