### PR TITLE
Improve Home screen UI

### DIFF
--- a/components/home/HeaderInfo.tsx
+++ b/components/home/HeaderInfo.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
+import { useAppTheme } from '../../hooks/useAppTheme';
+
+interface Props {
+  date: Date;
+}
+
+export default function HeaderInfo({ date }: Props) {
+  const theme = useAppTheme();
+  const formatted = date
+    .toLocaleDateString('es-ES', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+    })
+    .replace(/^\w/, (m) => m.toUpperCase());
+  return <Text style={[styles.text, { color: theme.colors.darkGray }]}>{formatted}</Text>;
+}
+
+const styles = StyleSheet.create({
+  text: { fontSize: 18, marginBottom: 16 },
+});

--- a/components/home/PlayButton.tsx
+++ b/components/home/PlayButton.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { TouchableOpacity, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useAppTheme } from '../../hooks/useAppTheme';
+
+interface Props {
+  onPress: () => void;
+}
+
+export default function PlayButton({ onPress }: Props) {
+  const theme = useAppTheme();
+  return (
+    <TouchableOpacity
+      style={[styles.button, { backgroundColor: theme.colors.primary }]}
+      onPress={onPress}
+    >
+      <Ionicons name="play" size={60} color={theme.colors.white} />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    alignItems: 'center',
+    justifyContent: 'center',
+    elevation: 4,
+    marginVertical: 24,
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+  },
+});

--- a/components/home/ProgressDisplay.tsx
+++ b/components/home/ProgressDisplay.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useAppTheme } from '../../hooks/useAppTheme';
+
+interface Props {
+  distance: number;
+  goal: number;
+}
+
+export default function ProgressDisplay({ distance, goal }: Props) {
+  const theme = useAppTheme();
+  const ratio = Math.min(distance / goal, 1);
+
+  let message = '¡Recién empieza!';
+  if (ratio >= 1) message = '¡Objetivo completado!';
+  else if (ratio > 0.75) message = '¡Casi llegás!';
+  else if (ratio > 0.4) message = '¡Vas bien!';
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.progressText, { color: theme.colors.text }]}>
+        {' '}
+        {distance.toFixed(1)} / {goal} km
+      </Text>
+      <View style={[styles.barBackground, { backgroundColor: theme.colors.gray }]}>
+        <View
+          style={[styles.bar, { backgroundColor: theme.colors.primary, width: `${ratio * 100}%` }]}
+        />
+      </View>
+      <Text style={[styles.message, { color: theme.colors.primary }]}>{message}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { width: '100%', alignItems: 'center' },
+  progressText: { fontWeight: 'bold', marginBottom: 8 },
+  barBackground: { width: '100%', height: 10, borderRadius: 5, overflow: 'hidden' },
+  bar: { height: 10 },
+  message: { marginTop: 8, fontSize: 16 },
+});

--- a/components/home/TipMessage.tsx
+++ b/components/home/TipMessage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
+import { useAppTheme } from '../../hooks/useAppTheme';
+
+interface Props {
+  text: string;
+}
+
+export default function TipMessage({ text }: Props) {
+  const theme = useAppTheme();
+  return <Text style={[styles.text, { color: theme.colors.darkGray }]}>{text}</Text>;
+}
+
+const styles = StyleSheet.create({
+  text: {
+    marginTop: 24,
+    fontSize: 16,
+    textAlign: 'center',
+  },
+});

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
+import { View, StyleSheet, SafeAreaView, Text } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
-import { Ionicons } from '@expo/vector-icons';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { usePendingActivities } from '../context/PendingActivitiesContext';
 import { useUser } from '../hooks/useUser';
 import { getMonthlyProgress } from '../services/walkService';
-import MonthlyProgress from '../components/MonthlyProgress';
+import HeaderInfo from '../components/home/HeaderInfo';
+import PlayButton from '../components/home/PlayButton';
+import ProgressDisplay from '../components/home/ProgressDisplay';
+import TipMessage from '../components/home/TipMessage';
 
 export default function Home({ navigation }: any) {
   const theme = useAppTheme();
@@ -49,18 +51,14 @@ export default function Home({ navigation }: any) {
         </View>
       )}
       <View style={styles.centerContent}>
-        <Text style={styles.title}>VAMOS COMEÇAR?</Text>
-        <TouchableOpacity style={styles.playButton} onPress={() => navigation.navigate('Activity')}>
-          <Ionicons name="play" size={60} color={theme.colors.white} style={{ marginLeft: 6 }} />
-        </TouchableOpacity>
-        <Text style={styles.subtitle}>
-          pressione o botão para iniciar uma nova atividade física
-        </Text>
+        <HeaderInfo date={new Date()} />
+        <PlayButton onPress={() => navigation.navigate('Activity')} />
         {user && (
           <View style={styles.progressWrapper}>
-            <MonthlyProgress totalKm={totalKm} goalKm={monthlyGoalKm} />
+            <ProgressDisplay distance={totalKm} goal={monthlyGoalKm} />
           </View>
         )}
+        <TipMessage text="¡Sigue moviéndote cada día!" />
       </View>
     </SafeAreaView>
   );
@@ -77,33 +75,6 @@ const createStyles = (theme: any) =>
       justifyContent: 'center',
       alignItems: 'center',
       paddingHorizontal: 24,
-    },
-    title: {
-      fontSize: 32,
-      fontWeight: 'bold',
-      color: theme.colors.primary,
-      textAlign: 'center',
-      marginBottom: 24,
-    },
-    playButton: {
-      backgroundColor: theme.colors.primary,
-      borderRadius: 100,
-      width: 120,
-      height: 120,
-      alignItems: 'center',
-      justifyContent: 'center',
-      marginVertical: 24,
-      elevation: 4,
-    },
-    playIcon: {
-      fontSize: 60,
-      color: theme.colors.white,
-    },
-    subtitle: {
-      fontSize: 16,
-      color: theme.colors.darkGray,
-      textAlign: 'center',
-      paddingHorizontal: 20,
     },
     pendingBadge: {
       position: 'absolute',


### PR DESCRIPTION
## Summary
- add modular home components: HeaderInfo, PlayButton, ProgressDisplay and TipMessage
- redesign Home screen to use new components in Spanish

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run format`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bd20da8c48322a6dbabfa79ff02cb