### PR TITLE
Implement offline syncing and monthly stats

### DIFF
--- a/components/home/ProgressDisplay.tsx
+++ b/components/home/ProgressDisplay.tsx
@@ -5,9 +5,10 @@ import { useAppTheme } from '../../hooks/useAppTheme';
 interface Props {
   distance: number;
   goal: number;
+  benefit?: string;
 }
 
-export default function ProgressDisplay({ distance, goal }: Props) {
+export default function ProgressDisplay({ distance, goal, benefit }: Props) {
   const theme = useAppTheme();
   const ratio = Math.min(distance / goal, 1);
 
@@ -28,6 +29,9 @@ export default function ProgressDisplay({ distance, goal }: Props) {
         />
       </View>
       <Text style={[styles.message, { color: theme.colors.primary }]}>{message}</Text>
+      {benefit ? (
+        <Text style={[styles.benefit, { color: theme.colors.darkGray }]}>{benefit}</Text>
+      ) : null}
     </View>
   );
 }
@@ -38,4 +42,5 @@ const styles = StyleSheet.create({
   barBackground: { width: '100%', height: 10, borderRadius: 5, overflow: 'hidden' },
   bar: { height: 10 },
   message: { marginTop: 8, fontSize: 16 },
+  benefit: { marginTop: 4, fontSize: 14 },
 });

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -9,6 +9,22 @@ export function useUser() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    const loadStored = async () => {
+      try {
+        const stored = await AsyncStorage.getItem('user');
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          setUser(parsed as User);
+        }
+      } catch {
+        // ignore parse errors
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadStored();
+
     const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
       if (firebaseUser) {
         AsyncStorage.setItem(
@@ -19,7 +35,6 @@ export function useUser() {
         AsyncStorage.removeItem('user');
       }
       setUser(firebaseUser);
-      setLoading(false);
     });
 
     return () => unsubscribe(); // Limpia el listener

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -55,7 +55,11 @@ export default function Home({ navigation }: any) {
         <PlayButton onPress={() => navigation.navigate('Activity')} />
         {user && (
           <View style={styles.progressWrapper}>
-            <ProgressDisplay distance={totalKm} goal={monthlyGoalKm} />
+            <ProgressDisplay
+              distance={totalKm}
+              goal={monthlyGoalKm}
+              benefit="20 km → 10% de descuento"
+            />
           </View>
         )}
         <TipMessage text="¡Sigue moviéndote cada día!" />

--- a/services/activityService.ts
+++ b/services/activityService.ts
@@ -32,10 +32,6 @@ export const uploadActivity = async (activity: LocalActivity) => {
   try {
     const user = auth.currentUser;
     if (!user) throw new Error('Usuario no autenticado');
-    if (activity.duration < 300) {
-      logEvent('UPLOAD', 'Actividad descartada: menos de 5 minutos');
-      return;
-    }
 
     await addDoc(collection(db, 'activities'), {
       userId: user.uid,


### PR DESCRIPTION
## Summary
- persist user session info in AsyncStorage
- keep all activities when saving, even under 5 minutes
- show monthly progress stats grouped by month
- display benefit text in progress bar

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686bfbaf1d4c8322879ea92e74706950