### PR TITLE
Add offline sync and monthly stats

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,11 +14,13 @@ import { EmojiProvider } from './context/EmojiContext';
 import { PendingActivityProvider } from './context/PendingActivitiesContext';
 import { useUser } from './hooks/useUser';
 import useGlobalNetwork from './hooks/useGlobalNetwork';
+import useActivitySync from './hooks/useActivitySync';
 
 const Stack = createNativeStackNavigator();
 
 export default function App() {
   useGlobalNetwork();
+  useActivitySync();
   const { user, loading } = useUser();
   const initialRoute = user ? 'MainTabs' : 'Splash';
 

--- a/__tests__/stats.test.ts
+++ b/__tests__/stats.test.ts
@@ -1,0 +1,26 @@
+const { groupByMonth } = require('../utils/stats');
+
+describe('groupByMonth', () => {
+  it('aggregates activities by month', () => {
+    const activities = [
+      { date: new Date('2024-05-01'), distance: 5, duration: 30 },
+      { date: new Date('2024-05-10'), distance: 3, duration: 20 },
+      { date: new Date('2024-06-02'), distance: 10, duration: 60 },
+    ];
+    const result = groupByMonth(activities);
+    expect(result).toEqual([
+      {
+        month: '05/2024',
+        totalActivities: 2,
+        totalDistance: 8,
+        totalTime: 50,
+      },
+      {
+        month: '06/2024',
+        totalActivities: 1,
+        totalDistance: 10,
+        totalTime: 60,
+      },
+    ]);
+  });
+});

--- a/hooks/useActivitySync.ts
+++ b/hooks/useActivitySync.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { setupActivitySync } from '../services/activityService';
+
+let initialized = false;
+
+export default function useActivitySync() {
+  useEffect(() => {
+    if (initialized) return;
+    initialized = true;
+    setupActivitySync();
+    return () => undefined;
+  }, []);
+}

--- a/hooks/useAuthUser.ts
+++ b/hooks/useAuthUser.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { User, onAuthStateChanged } from 'firebase/auth';
+import { auth } from '../firebase/firebase';
+
+export default function useAuthUser() {
+  const [user, setUser] = useState<User | null>(auth.currentUser);
+  const [initializing, setInitializing] = useState(true);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setInitializing(false);
+    });
+    return () => unsub();
+  }, []);
+
+  return { user, initializing };
+}

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -5,13 +5,13 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { useNavigation } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAppTheme } from '../hooks/useAppTheme';
-import { useUser } from '../hooks/useUser';
+import useAuthUser from '../hooks/useAuthUser';
 import { useEmoji } from '../context/EmojiContext';
 import { auth } from '../firebase/firebase';
 
 export default function Profile() {
   const navigation = useNavigation<any>();
-  const { user } = useUser();
+  const { user: authUser, initializing } = useAuthUser();
   const { emoji, setEmoji } = useEmoji();
   const theme = useAppTheme();
   const [modalVisible, setModalVisible] = React.useState(false);
@@ -96,7 +96,11 @@ export default function Profile() {
         <View style={styles.avatar}>
           <Text style={styles.emojiAvatar}>{emoji}</Text>
         </View>
-        <Text style={styles.email}>{user?.email}</Text>
+        {initializing ? (
+          <Text style={styles.email}>Cargando usuario...</Text>
+        ) : (
+          <Text style={styles.email}>{authUser?.email}</Text>
+        )}
 
         <TouchableOpacity
           style={[

--- a/screens/Stats.tsx
+++ b/screens/Stats.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { getUserActivitiesSummary, MonthlySummary } from '../services/activityService';
+import ProgressDisplay from '../components/home/ProgressDisplay';
 import { useUser } from '../hooks/useUser';
 import { format } from 'date-fns';
 import es from 'date-fns/locale/es';
@@ -14,6 +15,10 @@ export default function Stats() {
   const [summary, setSummary] = useState<MonthlySummary[]>([]);
   const [loadingSummary, setLoadingSummary] = useState(true);
   const theme = useAppTheme();
+  const monthlyGoal = 30;
+  const currentMonthKey = format(new Date(), 'MM/yyyy');
+  const current = summary.find((s) => s.month === currentMonthKey);
+  const currentKm = current ? current.totalDistance : 0;
   const styles = StyleSheet.create({
     container: { flex: 1, backgroundColor: theme.colors.background, paddingTop: 40 },
     header: {
@@ -37,6 +42,8 @@ export default function Stats() {
     },
     itemMonth: { color: theme.colors.text, fontWeight: 'bold' },
     itemKm: { color: theme.colors.primary },
+    itemInfo: { color: theme.colors.text, fontSize: 12 },
+    progressWrapper: { paddingHorizontal: 16, marginBottom: 20 },
   });
   useEffect(() => {
     const load = async () => {
@@ -57,8 +64,14 @@ export default function Stats() {
     const label = format(date, 'MMMM yyyy', { locale: es });
     return (
       <View style={styles.item}>
-        <Text style={styles.itemMonth}>{label}</Text>
-        <Text style={styles.itemKm}>{item.totalDistance.toFixed(2)} km</Text>
+        <View>
+          <Text style={styles.itemMonth}>{label}</Text>
+          <Text style={styles.itemInfo}>{item.totalActivities} actividades</Text>
+        </View>
+        <View style={{ alignItems: 'flex-end' }}>
+          <Text style={styles.itemKm}>{item.totalDistance.toFixed(2)} km</Text>
+          <Text style={styles.itemInfo}>{Math.round(item.totalTime / 60)} min</Text>
+        </View>
       </View>
     );
   };
@@ -77,12 +90,17 @@ export default function Stats() {
           <ActivityIndicator size="large" color={theme.colors.primary} />
         </View>
       ) : (
-        <FlatList
-          data={summary}
-          keyExtractor={(item) => item.month}
-          renderItem={renderItem}
-          contentContainerStyle={{ paddingBottom: 40 }}
-        />
+        <>
+          <View style={styles.progressWrapper}>
+            <ProgressDisplay distance={currentKm} goal={monthlyGoal} />
+          </View>
+          <FlatList
+            data={summary}
+            keyExtractor={(item) => item.month}
+            renderItem={renderItem}
+            contentContainerStyle={{ paddingBottom: 40 }}
+          />
+        </>
       )}
     </SafeAreaView>
   );

--- a/services/activityService.ts
+++ b/services/activityService.ts
@@ -54,23 +54,25 @@ export const saveActivityWithCache = async (
   activity: Omit<LocalActivity, 'id' | 'conexion_al_guardar'>,
 ) => {
   const netInfo = await NetInfo.fetch();
-  const conexion = netInfo.isConnected ? netInfo.type : 'none';
+  const online = Boolean(netInfo.isConnected) && netInfo.isInternetReachable !== false;
+  const conexion = online ? netInfo.type : 'offline';
   const data: LocalActivity = {
     ...activity,
     id: generateId(),
     conexion_al_guardar: conexion,
   };
-  try {
-    await uploadActivity(data);
-  } catch (error) {
-    logEvent('UPLOAD', `Error al guardar, se guarda localmente: ${error}`);
-    const stored = await AsyncStorage.getItem(PENDING_KEY);
-    const pending: LocalActivity[] = stored ? JSON.parse(stored) : [];
-    if (!pending.find((p) => p.id === data.id)) {
-      pending.push(data);
-      await AsyncStorage.setItem(PENDING_KEY, JSON.stringify(pending));
+  if (online) {
+    try {
+      await uploadActivity(data);
+      return;
+    } catch (error) {
+      logEvent('UPLOAD', `Error al guardar online: ${error}`);
     }
   }
+  const stored = await AsyncStorage.getItem(PENDING_KEY);
+  const pending: LocalActivity[] = stored ? JSON.parse(stored) : [];
+  pending.push(data);
+  await AsyncStorage.setItem(PENDING_KEY, JSON.stringify(pending));
 };
 
 export const syncPendingActivities = async () => {
@@ -100,6 +102,21 @@ export const syncPendingActivities = async () => {
     await AsyncStorage.setItem(PENDING_KEY, JSON.stringify(remaining));
     console.log(`\uD83E\uDEA5 [SYNC] Quedaron ${remaining.length} pendientes`);
   }
+};
+
+let listenerAdded = false;
+export const setupActivitySync = async () => {
+  if (listenerAdded) return;
+  listenerAdded = true;
+  const state = await NetInfo.fetch();
+  if (state.isConnected && state.isInternetReachable !== false) {
+    syncPendingActivities().catch(() => undefined);
+  }
+  NetInfo.addEventListener((info) => {
+    if (info.isConnected && info.isInternetReachable !== false) {
+      syncPendingActivities().catch(() => undefined);
+    }
+  });
 };
 
 export const getActivitiesByUser = async (userId: string) => {

--- a/utils/stats.js
+++ b/utils/stats.js
@@ -1,0 +1,19 @@
+function groupByMonth(activities) {
+  const map = new Map();
+  activities.forEach((a) => {
+    const key = `${String(a.date.getMonth() + 1).padStart(2, '0')}/${a.date.getFullYear()}`;
+    const entry = map.get(key) || { count: 0, dist: 0, time: 0 };
+    entry.count += 1;
+    entry.dist += a.distance;
+    entry.time += a.duration;
+    map.set(key, entry);
+  });
+  return Array.from(map.entries()).map(([month, stats]) => ({
+    month,
+    totalActivities: stats.count,
+    totalDistance: Number(stats.dist.toFixed(2)),
+    totalTime: stats.time,
+  }));
+}
+
+module.exports = { groupByMonth };


### PR DESCRIPTION
## Summary
- implement offline caching and automatic sync for activities
- show monthly progress bar and detailed stats
- fix profile user load with `useAuthUser`
- add hooks for activity syncing
- create simple stats utility with Jest test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c061436ec8322a5c4443ca86453d9