### PR TITLE
Add new activity validation fields

### DIFF
--- a/__tests__/stats.test.ts
+++ b/__tests__/stats.test.ts
@@ -1,4 +1,4 @@
-const { groupByMonth } = require('../utils/stats');
+const { groupByMonth, calculateAverageSpeed, evaluateActivityStatus } = require('../utils/stats');
 
 describe('groupByMonth', () => {
   it('aggregates activities by month', () => {
@@ -22,5 +22,25 @@ describe('groupByMonth', () => {
         totalTime: 60,
       },
     ]);
+  });
+});
+
+describe('calculateAverageSpeed', () => {
+  it('computes km/h correctly', () => {
+    const speed = calculateAverageSpeed(2, 1800); // 2 km in 30 min
+    expect(speed).toBe(4);
+  });
+});
+
+describe('evaluateActivityStatus', () => {
+  it('marks activity valid if checks pass', () => {
+    const res = evaluateActivityStatus(1, 600); // 1 km in 10 min -> 6 km/h
+    expect(res).toEqual({ status: 'valida', velocidadPromedio: 6 });
+  });
+
+  it('detects vehicle usage by speed', () => {
+    const res = evaluateActivityStatus(10, 1200); // 10 km in 20 min -> 30 km/h
+    expect(res.status).toBe('invalida');
+    expect(res.invalidReason).toBe('vehiculo');
   });
 });

--- a/context/PendingActivitiesContext.tsx
+++ b/context/PendingActivitiesContext.tsx
@@ -12,7 +12,11 @@ export interface PendingActivity {
   duration: number;
   route: LocationObjectCoords[];
   date: string;
-  conexion_al_guardar: string;
+  conexion: 'wifi' | 'datos_moviles' | 'offline';
+  metodoGuardado: 'online' | 'offline_post_sync';
+  status: 'pendiente' | 'valida' | 'invalida';
+  invalidReason?: 'vehiculo' | 'no_es_usuario';
+  velocidadPromedio: number;
 }
 
 export type PendingActivityInput = Omit<PendingActivity, 'id'>;
@@ -51,7 +55,11 @@ const sendToFirebase = async (activity: PendingActivity): Promise<void> => {
         date: activity.date,
         distance: activity.distance,
         duration: activity.duration,
-        conexion_al_guardar: activity.conexion_al_guardar,
+        conexion: activity.conexion,
+        metodoGuardado: activity.metodoGuardado,
+        status: activity.status,
+        invalidReason: activity.invalidReason,
+        velocidadPromedio: activity.velocidadPromedio,
         id: activity.id,
       }),
     },

--- a/services/activityService.ts
+++ b/services/activityService.ts
@@ -14,6 +14,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { auth } from '../firebase/firebase';
 import db from '../firebase/db';
 import { logEvent } from '../utils/logger';
+import { evaluateActivityStatus } from '../utils/stats';
 
 export interface LocalActivity {
   id: string;
@@ -21,7 +22,11 @@ export interface LocalActivity {
   endTime: string;
   distance: number;
   duration: number;
-  conexion_al_guardar: string;
+  conexion: 'wifi' | 'datos_moviles' | 'offline';
+  metodoGuardado: 'online' | 'offline_post_sync';
+  status: 'pendiente' | 'valida' | 'invalida';
+  invalidReason?: 'vehiculo' | 'no_es_usuario';
+  velocidadPromedio: number;
 }
 
 const PENDING_KEY = 'PENDING_ACTIVITIES_V2';
@@ -40,7 +45,11 @@ export const uploadActivity = async (activity: LocalActivity) => {
       duration: activity.duration,
       distance: activity.distance,
       date: Timestamp.fromDate(new Date(activity.startTime)),
-      conexion_al_guardar: activity.conexion_al_guardar,
+      conexion: activity.conexion,
+      metodoGuardado: activity.metodoGuardado,
+      status: activity.status,
+      invalidReason: activity.invalidReason,
+      velocidadPromedio: activity.velocidadPromedio,
     });
 
     logEvent('UPLOAD', 'Actividad guardada en Firebase');
@@ -51,15 +60,20 @@ export const uploadActivity = async (activity: LocalActivity) => {
 };
 
 export const saveActivityWithCache = async (
-  activity: Omit<LocalActivity, 'id' | 'conexion_al_guardar'>,
+  activity: Omit<LocalActivity, 'id' | 'conexion' | 'metodoGuardado' | 'status' | 'invalidReason' | 'velocidadPromedio'>,
 ) => {
   const netInfo = await NetInfo.fetch();
   const online = Boolean(netInfo.isConnected) && netInfo.isInternetReachable !== false;
-  const conexion = online ? netInfo.type : 'offline';
+  const conexion = online ? (netInfo.type === 'wifi' ? 'wifi' : 'datos_moviles') : 'offline';
+  const evalRes = evaluateActivityStatus(activity.distance, activity.duration);
   const data: LocalActivity = {
     ...activity,
     id: generateId(),
-    conexion_al_guardar: conexion,
+    conexion,
+    metodoGuardado: online ? 'online' : 'offline_post_sync',
+    status: evalRes.status,
+    invalidReason: evalRes.invalidReason,
+    velocidadPromedio: evalRes.velocidadPromedio,
   };
   if (online) {
     try {

--- a/utils/stats.js
+++ b/utils/stats.js
@@ -16,4 +16,20 @@ function groupByMonth(activities) {
   }));
 }
 
-module.exports = { groupByMonth };
+function calculateAverageSpeed(distanceKm, durationSec) {
+  if (!durationSec) return 0;
+  return Number(((distanceKm / (durationSec / 3600)).toFixed(2)));
+}
+
+function evaluateActivityStatus(distanceKm, durationSec) {
+  const velocidadPromedio = calculateAverageSpeed(distanceKm, durationSec);
+  if (velocidadPromedio > 20) {
+    return { status: 'invalida', invalidReason: 'vehiculo', velocidadPromedio };
+  }
+  if (durationSec < 300) {
+    return { status: 'invalida', invalidReason: 'no_es_usuario', velocidadPromedio };
+  }
+  return { status: 'valida', velocidadPromedio };
+}
+
+module.exports = { groupByMonth, calculateAverageSpeed, evaluateActivityStatus };


### PR DESCRIPTION
## Summary
- expand Activity model with status, reasons and speed
- compute average speed and evaluate activity integrity
- persist extended info offline and on sync
- update saving flow to use new fields
- cover new util functions with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e82464dbc8322b1f82e79e66d327d