### PR TITLE
Fix pending activities sync logic

### DIFF
--- a/context/PendingActivitiesContext.tsx
+++ b/context/PendingActivitiesContext.tsx
@@ -17,13 +17,14 @@ export interface PendingActivity {
   status: 'pendiente' | 'valida' | 'invalida';
   invalidReason?: 'vehiculo' | 'no_es_usuario';
   velocidadPromedio: number;
+  aceleracionPromedio: number;
 }
 
 export type PendingActivityInput = Omit<PendingActivity, 'id'>;
 
 interface PendingCtx {
   pending: PendingActivity[];
-  add(activity: PendingActivityInput): void;
+  add(activity: PendingActivityInput): Promise<void>;
   sync(): Promise<void>;
   logPending(): void;
   pendingCount: number;
@@ -46,20 +47,35 @@ const sendToFirebase = async (activity: PendingActivity): Promise<void> => {
   const userId = getAuth().currentUser?.uid;
   if (!userId) throw new Error('no-auth');
 
+  // Solo enviar los campos requeridos, excluyendo `route`
+  const {
+    id,
+    date,
+    distance,
+    duration,
+    status,
+    invalidReason,
+    metodoGuardado,
+    velocidadPromedio,
+    conexion,
+    aceleracionPromedio,
+  } = activity;
+
   const payload = {
+    id,
     userId,
-    date: activity.date,
-    distance: activity.distance,
-    duration: activity.duration,
-    conexion: activity.conexion,
-    metodoGuardado: activity.metodoGuardado,
-    status: activity.status,
-    invalidReason: activity.invalidReason,
-    velocidadPromedio: activity.velocidadPromedio,
-    id: activity.id,
+    date,
+    distance,
+    duration,
+    status,
+    invalidReason,
+    metodoGuardado,
+    velocidadPromedio,
+    conexion,
+    aceleracionPromedio,
   };
 
-  console.log(`🚀 Subiendo actividad: ${activity.id} para usuario ${userId} →`, payload);
+  console.log(`🚀 Subiendo actividad: ${id} para usuario ${userId} →`, payload);
 
   const response = await fetch(
     'https://us-central1-prueba1fedentz.cloudfunctions.net/saveActivity',
@@ -82,24 +98,39 @@ export const PendingActivityProvider: React.FC<{ children: React.ReactNode }> = 
   const keyRef = useRef('');
   const uploadedKeyRef = useRef('');
   const uploadedRef = useRef<string[]>([]);
+  const pendingRef = useRef<PendingActivity[]>([]);
+  const isSyncingRef = useRef(false);
 
 const sync = async () => {
-  console.log('🔄 [SYNC] Iniciando sincronización de actividades...');
-
-  const state = await NetInfo.fetch();
-  const online = Boolean(state.isConnected) && state.isInternetReachable !== false;
-
-  if (!online) {
-    console.log('🚫 [SYNC] No hay conexión, abortando sincronización');
+  if (isSyncingRef.current) {
+    console.log('⏳ [SYNC] Ya se está ejecutando una sincronización');
     return;
   }
+  isSyncingRef.current = true;
+  try {
+    console.log('🔄 [SYNC] Iniciando sincronización de actividades...');
 
-  console.log(`✅ [SYNC] Conectado a internet, tipo: ${state.type}`);
-  console.log(`📦 [SYNC] Actividades pendientes: ${pending.length}`);
+    const state = await NetInfo.fetch();
+    const online = Boolean(state.isConnected) && state.isInternetReachable !== false;
+
+    if (!online) {
+      console.log('🚫 [SYNC] No hay conexión, abortando sincronización');
+      return;
+    }
+
+    const userId = getAuth().currentUser?.uid;
+    if (!userId) {
+      console.log('🚫 [SYNC] Usuario no autenticado, abortando sincronización');
+      return;
+    }
+
+    console.log(`✅ [SYNC] Conectado a internet, tipo: ${state.type}`);
+    console.log(`📦 [SYNC] Actividades pendientes: ${pendingRef.current.length}`);
 
   const remaining: PendingActivity[] = [];
 
-  for (const act of pending) {
+  const currentPending = pendingRef.current.slice();
+  for (const act of currentPending) {
     if (uploadedRef.current.includes(act.id)) {
       console.log(`⏩ [SYNC] Actividad ${act.id} ya fue subida, la salto`);
       continue;
@@ -120,19 +151,21 @@ const sync = async () => {
     }
   }
 
-  setPending(() => {
-    AsyncStorage.setItem(keyRef.current, JSON.stringify(remaining)).catch(() => undefined);
-    return remaining;
-  });
+  pendingRef.current = remaining;
+  setPending(remaining);
+  await AsyncStorage.setItem(keyRef.current, JSON.stringify(remaining)).catch(() => undefined);
 
   console.log('✅ [SYNC] Sincronización finalizada');
+  } finally {
+    isSyncingRef.current = false;
+  }
 };
 
 
-  const add = (activity: PendingActivityInput) => {
+  const add = async (activity: PendingActivityInput) => {
   const userId = getAuth().currentUser?.uid;
   if (!userId || !keyRef.current) {
-    console.error("🚨 [PENDING] No se puede agregar actividad: usuario no autenticado o key vacía");
+    console.error('🚨 [PENDING] No se puede agregar actividad: usuario no autenticado o key vacía');
     return;
   }
 
@@ -143,22 +176,20 @@ const sync = async () => {
 
   console.log('➕ [PENDING] Agregando actividad local:', withId);
 
-  setPending((prev) => {
-    const updated = [...prev, withId];
-    AsyncStorage.setItem(keyRef.current!, JSON.stringify(updated))
-      .then(() => console.log("💾 [PENDING] Actividad guardada en AsyncStorage"))
-      .catch((e) => console.error("❌ [PENDING] Error guardando en AsyncStorage", e));
-    return updated;
-  });
+  const updated = [...pendingRef.current, withId];
+  pendingRef.current = updated;
+  setPending(updated);
+  await AsyncStorage.setItem(keyRef.current, JSON.stringify(updated))
+    .then(() => console.log('💾 [PENDING] Actividad guardada en AsyncStorage'))
+    .catch((e) => console.error('❌ [PENDING] Error guardando en AsyncStorage', e));
 
   logEvent('ACTIVITY_SAVED_LOCALLY', JSON.stringify(withId));
 
-  setTimeout(async () => {
-  const stored = await AsyncStorage.getItem(keyRef.current!);
-  const parsed = stored ? JSON.parse(stored) : [];
-  console.log("🔁 [PENDING] Releyendo desde AsyncStorage:", parsed.length);
-  setPending(parsed);
-}, 500);
+  const state = await NetInfo.fetch();
+  const online = Boolean(state.isConnected) && state.isInternetReachable !== false;
+  if (online) {
+    await sync();
+  }
 
 };
 
@@ -197,7 +228,8 @@ const sync = async () => {
           if (stored) {
             const parsed = JSON.parse(stored);
             console.log('📥 [AUTH] Cargando actividades previas:', parsed.length);
-            setPending(JSON.parse(stored));
+            pendingRef.current = parsed;
+            setPending(parsed);
           }
           const uploaded = await AsyncStorage.getItem(uploadedKeyRef.current);
           if (uploaded) {
@@ -216,6 +248,7 @@ const sync = async () => {
         keyRef.current = '';
         uploadedKeyRef.current = '';
         setPending([]);
+        pendingRef.current = [];
         uploadedRef.current = [];
       }
     });
@@ -223,6 +256,7 @@ const sync = async () => {
   }, []);
 
   useEffect(() => {
+    pendingRef.current = pending;
     console.log('📥 [PENDING] Estado actualizado:', pending.length);
   }, [pending]);
 

--- a/screens/Activity.tsx
+++ b/screens/Activity.tsx
@@ -106,6 +106,7 @@ export default function Activity() {
       status,
       invalidReason,
       velocidadPromedio,
+      aceleracionPromedio: 0,
     });
 
     if (conexion !== 'offline') {


### PR DESCRIPTION
## Summary
- ensure all activity fields sent to Firebase without `route`
- include new `aceleracionPromedio` property
- fill placeholder when saving activity

## Testing
- `npm test`
- `npm run lint` *(shows warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686ea856671483228b8002baa44711bf