### PR TITLE
Add Activity and User models

### DIFF
--- a/models/ActivityModel.ts
+++ b/models/ActivityModel.ts
@@ -1,0 +1,95 @@
+import { Timestamp } from 'firebase/firestore';
+import type { LocalActivity } from '../services/activityService';
+
+export type Conexion = 'wifi' | 'datos_moviles' | 'offline';
+export type MetodoGuardado = 'online' | 'offline_post_sync';
+export type ActivityStatus = 'pendiente' | 'valida' | 'invalida';
+export type InvalidReason = 'vehiculo' | 'no_es_usuario';
+
+export interface ActivityModelProps {
+  id: string;
+  userId: string;
+  startTime: Date;
+  endTime: Date;
+  date: Date;
+  duration: number;
+  distance: number;
+  conexion: Conexion;
+  metodoGuardado: MetodoGuardado;
+  status: ActivityStatus;
+  invalidReason?: InvalidReason;
+  velocidadPromedio: number;
+  aceleracionPromedio: number;
+}
+
+export default class ActivityModel {
+  id: string;
+  userId: string;
+  startTime: Date;
+  endTime: Date;
+  date: Date;
+  duration: number;
+  distance: number;
+  conexion: Conexion;
+  metodoGuardado: MetodoGuardado;
+  status: ActivityStatus;
+  invalidReason?: InvalidReason;
+  velocidadPromedio: number;
+  aceleracionPromedio: number;
+
+  constructor(props: ActivityModelProps) {
+    this.id = props.id;
+    this.userId = props.userId;
+    this.startTime = props.startTime;
+    this.endTime = props.endTime;
+    this.date = props.date;
+    this.duration = props.duration;
+    this.distance = props.distance;
+    this.conexion = props.conexion;
+    this.metodoGuardado = props.metodoGuardado;
+    this.status = props.status;
+    this.invalidReason = props.invalidReason;
+    this.velocidadPromedio = props.velocidadPromedio;
+    this.aceleracionPromedio = props.aceleracionPromedio;
+  }
+
+  static fromLocalActivity(
+    activity: LocalActivity,
+    userId: string,
+    aceleracionPromedio = 0,
+  ): ActivityModel {
+    return new ActivityModel({
+      id: activity.id,
+      userId,
+      startTime: new Date(activity.startTime),
+      endTime: new Date(activity.endTime),
+      date: new Date(activity.startTime),
+      duration: activity.duration,
+      distance: activity.distance,
+      conexion: activity.conexion,
+      metodoGuardado: activity.metodoGuardado,
+      status: activity.status,
+      invalidReason: activity.invalidReason,
+      velocidadPromedio: activity.velocidadPromedio,
+      aceleracionPromedio,
+    });
+  }
+
+  toFirestore() {
+    return {
+      userId: this.userId,
+      startTime: Timestamp.fromDate(this.startTime),
+      endTime: Timestamp.fromDate(this.endTime),
+      date: Timestamp.fromDate(this.date),
+      duration: this.duration,
+      distance: this.distance,
+      conexion: this.conexion,
+      metodoGuardado: this.metodoGuardado,
+      status: this.status,
+      invalidReason: this.invalidReason,
+      velocidadPromedio: this.velocidadPromedio,
+      aceleracionPromedio: this.aceleracionPromedio,
+    };
+  }
+}
+

--- a/models/UserModel.ts
+++ b/models/UserModel.ts
@@ -1,0 +1,24 @@
+export interface UserModelProps {
+  id: string;
+  email: string;
+  displayName?: string;
+}
+
+export default class UserModel {
+  id: string;
+  email: string;
+  displayName?: string;
+
+  constructor(props: UserModelProps) {
+    this.id = props.id;
+    this.email = props.email;
+    this.displayName = props.displayName;
+  }
+
+  toFirestore() {
+    return {
+      email: this.email,
+      displayName: this.displayName,
+    };
+  }
+}

--- a/services/activityService.ts
+++ b/services/activityService.ts
@@ -1,7 +1,6 @@
 import {
   collection,
   addDoc,
-  Timestamp,
   query,
   where,
   orderBy,
@@ -14,6 +13,7 @@ import { auth } from '../firebase/firebase';
 import db from '../firebase/db';
 import { logEvent } from '../utils/logger';
 import { evaluateActivityStatus } from '../utils/stats';
+import ActivityModel from '../models/ActivityModel';
 
 export interface LocalActivity {
   id: string;
@@ -37,20 +37,7 @@ export const uploadActivity = async (activity: LocalActivity) => {
     const user = auth.currentUser;
     if (!user) throw new Error('Usuario no autenticado');
 
-    const payload = {
-      userId: user.uid,
-      startTime: Timestamp.fromDate(new Date(activity.startTime)),
-      endTime: Timestamp.fromDate(new Date(activity.endTime)),
-      duration: activity.duration,
-      distance: activity.distance,
-      date: Timestamp.fromDate(new Date(activity.startTime)),
-      conexion: activity.conexion,
-      metodoGuardado: activity.metodoGuardado,
-      status: activity.status,
-      invalidReason: activity.invalidReason,
-      velocidadPromedio: activity.velocidadPromedio,
-
-    };
+    const payload = ActivityModel.fromLocalActivity(activity, user.uid).toFirestore();
     console.log(
       `\uD83D\uDE80 Subiendo actividad: ${activity.id} para usuario ${user.uid} \u2192`,
       payload,


### PR DESCRIPTION
## Summary
- define `ActivityModel` and `UserModel` classes with Firestore helpers
- use `ActivityModel` in `uploadActivity`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ecc1c14ac83228afa3263266d4f25