### PR TITLE
Add payload logging before Firebase upload

### DIFF
--- a/context/PendingActivitiesContext.tsx
+++ b/context/PendingActivitiesContext.tsx
@@ -76,6 +76,7 @@ const sendToFirebase = async (activity: PendingActivity): Promise<void> => {
   };
 
   console.log(`🚀 Subiendo actividad: ${id} para usuario ${userId} →`, payload);
+  console.log('[UPLOAD] Payload a Firebase:', payload);
 
   const response = await fetch(
     'https://us-central1-prueba1fedentz.cloudfunctions.net/saveActivity',

--- a/services/activityService.ts
+++ b/services/activityService.ts
@@ -42,6 +42,7 @@ export const uploadActivity = async (activity: LocalActivity) => {
       `\uD83D\uDE80 Subiendo actividad: ${activity.id} para usuario ${user.uid} \u2192`,
       payload,
     );
+    console.log('[UPLOAD] Payload a Firebase:', payload);
     await addDoc(collection(db, 'activities'), payload);
 
 


### PR DESCRIPTION
## Summary
- add upload payload console in `sendToFirebase`
- add upload payload console in `uploadActivity`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ee1c4514083228d9854900f7ac942