### PR TITLE
Rework Stats screen layout and fix auth persistence

### DIFF
--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -9,6 +9,7 @@ export function useUser() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    let unsub: () => void;
     const loadStored = async () => {
       try {
         const stored = await AsyncStorage.getItem('user');
@@ -18,14 +19,12 @@ export function useUser() {
         }
       } catch {
         // ignore parse errors
-      } finally {
-        setLoading(false);
       }
     };
 
     loadStored();
 
-    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+    unsub = onAuthStateChanged(auth, (firebaseUser) => {
       if (firebaseUser) {
         AsyncStorage.setItem(
           'user',
@@ -35,9 +34,12 @@ export function useUser() {
         AsyncStorage.removeItem('user');
       }
       setUser(firebaseUser);
+      setLoading(false);
     });
 
-    return () => unsubscribe(); // Limpia el listener
+    return () => {
+      if (unsub) unsub();
+    };
   }, []);
 
   return { user, loading };


### PR DESCRIPTION
## Summary
- fix `useUser` so `loading` ends only after Firebase auth is ready
- simplify Stats: remove monthly summary and progress bar
- show activity list with PT‑BR date formatting and colored status
- wait for auth to initialize before loading activities

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eed5602d48322966f80dacb5cc254