### PR TITLE
Delay startup actions until auth ready

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,7 +21,16 @@ const Stack = createNativeStackNavigator();
 export default function App() {
   useGlobalNetwork();
   useActivitySync();
-  const { user, loading } = useUser();
+  const { user, loading, authInitialized } = useUser();
+
+  if (!authInitialized) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
   const initialRoute = user ? 'MainTabs' : 'Splash';
 
   if (loading) {

--- a/hooks/useActivitySync.ts
+++ b/hooks/useActivitySync.ts
@@ -1,13 +1,16 @@
 import { useEffect } from 'react';
 import { setupActivitySync } from '../services/activityService';
+import { useUser } from './useUser';
 
 let initialized = false;
 
 export default function useActivitySync() {
+  const { authInitialized } = useUser();
+
   useEffect(() => {
-    if (initialized) return;
+    if (!authInitialized || initialized) return;
     initialized = true;
     setupActivitySync();
     return () => undefined;
-  }, []);
+  }, [authInitialized]);
 }

--- a/hooks/useGlobalNetwork.ts
+++ b/hooks/useGlobalNetwork.ts
@@ -5,6 +5,7 @@ import NetInfo, { NetInfoStateType } from '@react-native-community/netinfo';
 
 import type { LocationObjectCoords } from 'expo-location';
 import { getAuth } from 'firebase/auth';
+import { useUser } from './useUser';
 import { logEvent, logDebug } from '../utils/logger';
 
 export interface TrackData {
@@ -45,8 +46,10 @@ export default function useGlobalNetwork() {
   const processing = useRef(false);
   const reintentando = useRef(false);
   const prevType = useRef<NetInfoStateType | 'none' | 'unknown'>('unknown');
+  const { authInitialized } = useUser();
 
   useEffect(() => {
+    if (!authInitialized) return;
     // Prueba mínima para verificar NetInfo
     NetInfo.fetch().then((state) =>
       logDebug(`[GLOBAL NETWORK] Estado inicial: ${state.isConnected ? state.type : 'offline'}`),
@@ -147,7 +150,7 @@ export default function useGlobalNetwork() {
     });
 
     return () => unsubscribe();
-  }, []);
+  }, [authInitialized]);
 
   return null;
 }

--- a/screens/Login.tsx
+++ b/screens/Login.tsx
@@ -9,7 +9,6 @@ import {
   ActivityIndicator,
   SafeAreaView,
 } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { loginWithEmail } from '../services/authService';
@@ -56,7 +55,6 @@ export default function Login({ navigation }: any) {
     try {
       setLoading(true);
       await loginWithEmail(email, password);
-      await AsyncStorage.setItem('user', JSON.stringify(auth.currentUser));
       navigation.replace('MainTabs');
     } catch (error: any) {
       if (error.code === 'auth/user-not-found') {

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { View, TouchableOpacity, Text, StyleSheet, SafeAreaView, Modal } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useNavigation } from '@react-navigation/native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAppTheme } from '../hooks/useAppTheme';
 import useAuthUser from '../hooks/useAuthUser';
 import { useEmoji } from '../context/EmojiContext';
@@ -72,7 +71,6 @@ export default function Profile() {
   const handleLogout = async () => {
     try {
       await signOut(auth);
-      await AsyncStorage.removeItem('user');
       navigation.replace('Login');
     } catch (error) {
       console.error('Erro ao sair:', error);


### PR DESCRIPTION
## Summary
- expose `authInitialized` from useUser hook
- wait for Firebase auth before picking the first route
- avoid running activity sync and network logic until auth is ready
- remove redundant AsyncStorage user storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f027241a883229113d966aad28de1