### PR TITLE
Ensure stats wait for Firebase auth

### DIFF
--- a/components/ActivityRecord.tsx
+++ b/components/ActivityRecord.tsx
@@ -13,7 +13,7 @@ type Activity = {
 };
 
 export default function Stats() {
-  const { user, loading } = useUser();
+  const { user, authInitialized } = useUser();
   const appTheme = useAppTheme();
   const { theme } = useTheme();
   const [activities, setActivities] = useState<Activity[]>([]);
@@ -21,7 +21,7 @@ export default function Stats() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!user) return;
+    if (!authInitialized || !user) return;
 
     const fetchActivities = async () => {
       try {
@@ -37,11 +37,11 @@ export default function Stats() {
     };
 
     fetchActivities();
-  }, [user]);
+  }, [user, authInitialized]);
 
   const s = styles(appTheme, theme);
 
-  if (loading || loadingActivities) {
+  if (!authInitialized || loadingActivities) {
     return (
       <View style={s.centered}>
         <ActivityIndicator size="large" color="#333" />

--- a/screens/Stats.tsx
+++ b/screens/Stats.tsx
@@ -18,13 +18,13 @@ import { getActivitiesByUser } from '../services/activityService';
 
 export default function Stats() {
   const navigation = useNavigation<any>();
-  const { user, loading: authLoading } = useUser();
+  const { user, authInitialized } = useUser();
   const [activities, setActivities] = useState<any[]>([]);
   const [loadingActivities, setLoadingActivities] = useState(true);
   const theme = useAppTheme();
 
   useEffect(() => {
-    if (authLoading) return;
+    if (!authInitialized) return;
     const loadActivities = async () => {
       if (!user) {
         setActivities([]);
@@ -40,7 +40,7 @@ export default function Stats() {
     };
     setLoadingActivities(true);
     loadActivities();
-  }, [user, authLoading]);
+  }, [user, authInitialized]);
 
 
 const renderActivity = ({ item }: { item: any }) => {
@@ -101,7 +101,7 @@ const renderActivity = ({ item }: { item: any }) => {
         <View style={{ width: 24 }} />
       </View>
 
-      {loadingActivities || authLoading ? (
+      {loadingActivities || !authInitialized ? (
         <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
           <ActivityIndicator size="large" color={theme.colors.primary} />
         </View>


### PR DESCRIPTION
## Summary
- use auth initialization flag in ActivityRecord and Stats
- avoid running effects until Firebase reports auth state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f05620d048322ac45cf60d9d6b0be