### PR TITLE
Fix Firebase Auth persistence

### DIFF
--- a/firebase/firebase.ts
+++ b/firebase/firebase.ts
@@ -17,29 +17,32 @@ const firebaseConfig = {
   googleClientId: Constants.expoConfig?.extra?.GOOGLE_CLIENT_ID || 'TU_GOOGLE_CLIENT_ID',
 };
 
-log('firebase/firebase.ts', 'init', 'FIREBASE', 'Verificando si hay apps de Firebase inicializadas...');
+log(
+  'firebase/firebase.ts',
+  'init',
+  'FIREBASE',
+  'Verificando si hay apps de Firebase inicializadas...',
+);
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 log(
   'firebase/firebase.ts',
   'init',
   'FIREBASE',
-  getApps().length
-    ? 'Firebase app existente encontrada.'
-    : 'Nueva app de Firebase inicializada.',
+  getApps().length ? 'Firebase app existente encontrada.' : 'Nueva app de Firebase inicializada.',
 );
 
 // Inicialización segura de Auth con persistencia
 let auth: Auth;
 try {
-  // Si ya fue inicializado, reutiliza
-  auth = getAuth(app);
-  log('firebase/firebase.ts', 'init', 'FIREBASE', 'Firebase Auth ya estaba inicializado.');
-} catch (e) {
-  log('firebase/firebase.ts', 'init', 'FIREBASE', 'Inicializando Firebase Auth con persistencia...');
   auth = initializeAuth(app, {
     persistence: getReactNativePersistence(AsyncStorage),
   });
   log('firebase/firebase.ts', 'init', 'FIREBASE', 'Firebase Auth inicializado con persistencia.');
+} catch (e) {
+  auth = getAuth(app);
+  log('firebase/firebase.ts', 'init', 'FIREBASE', 'Firebase Auth ya estaba inicializado.');
 }
+
+console.log('[DEBUG] auth.currentUser al iniciar:', auth.currentUser);
 
 export { app, auth };

--- a/firebase/googleAuth.ts
+++ b/firebase/googleAuth.ts
@@ -1,14 +1,12 @@
 import * as Google from 'expo-auth-session/providers/google';
 import * as WebBrowser from 'expo-web-browser';
 import { useEffect } from 'react';
-import { getAuth, signInWithCredential, GoogleAuthProvider } from 'firebase/auth';
+import { signInWithCredential, GoogleAuthProvider } from 'firebase/auth';
 import Constants from 'expo-constants';
-import { app } from './firebase'; // Tu configuración Firebase
+import { app, auth } from './firebase'; // Tu configuración Firebase
 import { log } from '../utils/logger';
 
 WebBrowser.maybeCompleteAuthSession(); // Cierra correctamente la sesión en iOS
-
-const auth = getAuth(app);
 
 const clientId = Constants.expoConfig?.extra?.GOOGLE_CLIENT_ID; // tomado desde .env
 
@@ -22,7 +20,12 @@ export const useGoogleAuth = () => {
     if (response?.type === 'success') {
       const idToken = (response.authentication as any).id_token; // 👈 fix de TypeScript
       if (!idToken) {
-        log('firebase/googleAuth.ts', 'useGoogleAuth', 'WARN', 'No se recibió id_token en la respuesta de autenticación');
+        log(
+          'firebase/googleAuth.ts',
+          'useGoogleAuth',
+          'WARN',
+          'No se recibió id_token en la respuesta de autenticación',
+        );
         return;
       }
 

--- a/screens/ChangePassword.tsx
+++ b/screens/ChangePassword.tsx
@@ -1,11 +1,7 @@
 import React, { useState } from 'react';
 import { Text, TextInput, TouchableOpacity, StyleSheet, Alert, SafeAreaView } from 'react-native';
-import {
-  getAuth,
-  EmailAuthProvider,
-  reauthenticateWithCredential,
-  updatePassword,
-} from 'firebase/auth';
+import { EmailAuthProvider, reauthenticateWithCredential, updatePassword } from 'firebase/auth';
+import { auth } from '../firebase/firebase';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { useTheme } from '../context/ThemeContext';
@@ -34,7 +30,7 @@ export default function ChangePassword({ navigation }: any) {
       return;
     }
     try {
-      const user = getAuth().currentUser;
+      const user = auth.currentUser;
       if (!user || !user.email) throw new Error('Usuário não autenticado');
       const cred = EmailAuthProvider.credential(user.email, current);
       await reauthenticateWithCredential(user, cred);


### PR DESCRIPTION
## Summary
- initialize Firebase auth with persistence
- remove calls to `getAuth()` before auth initialization
- use shared `auth` instance across modules

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f278f61e48322b768a121af3df156