### PR TITLE
Fix initial tab and stats navigation

### DIFF
--- a/navigation/MainTabs.tsx
+++ b/navigation/MainTabs.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import Home from '../screens/Home';
-import Stats from '../screens/Stats';
+import StatsStack from './StatsStack';
 import Profile from '../screens/Profile';
+import { View } from 'react-native';
 import { useAppTheme } from '../hooks/useAppTheme';
 
 const Tab = createBottomTabNavigator();
@@ -12,6 +13,7 @@ export default function MainTabs() {
   const theme = useAppTheme();
   return (
     <Tab.Navigator
+      initialRouteName="Home"
       screenOptions={({ route }) => ({
         headerShown: false,
         tabBarShowLabel: false,
@@ -38,11 +40,15 @@ export default function MainTabs() {
           let icon = 'home';
           if (route.name === 'Stats') icon = 'bar-chart';
           if (route.name === 'Profile') icon = 'person';
-          return <Ionicons name={icon as any} size={size} color={color} />;
+          return (
+            <View style={{ justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+              <Ionicons name={icon as any} size={size} color={color} />
+            </View>
+          );
         },
       })}
     >
-      <Tab.Screen name="Stats" component={Stats} />
+      <Tab.Screen name="Stats" component={StatsStack} />
       <Tab.Screen name="Home" component={Home} />
       <Tab.Screen name="Profile" component={Profile} />
     </Tab.Navigator>

--- a/navigation/StatsStack.tsx
+++ b/navigation/StatsStack.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import Stats from '../screens/Stats';
+
+const Stack = createNativeStackNavigator();
+
+export default function StatsStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="StatsMain" component={Stats} />
+    </Stack.Navigator>
+  );
+}

--- a/screens/Stats.tsx
+++ b/screens/Stats.tsx
@@ -23,6 +23,7 @@ export default function Stats() {
   const [activities, setActivities] = useState<any[]>([]);
   const [loadingActivities, setLoadingActivities] = useState(true);
   const theme = useAppTheme();
+  const showBackButton = navigation.canGoBack();
 
   useEffect(() => {
     if (!authInitialized) return;
@@ -95,9 +96,13 @@ const renderActivity = ({ item }: { item: any }) => {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
-        </TouchableOpacity>
+        {showBackButton ? (
+          <TouchableOpacity onPress={() => navigation.goBack()}>
+            <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
+          </TouchableOpacity>
+        ) : (
+          <View style={{ width: 24 }} />
+        )}
         <Text style={styles.title}>Registro de Actividades</Text>
         <View style={{ width: 24 }} />
       </View>


### PR DESCRIPTION
## Summary
- ensure Home is initial tab and icons are centered
- wrap Stats inside its own stack so back button is handled
- conditionally show back button only when navigation can go back

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686fc8d450808322b40aed63372d8888