### PR TITLE
Add i18n to all screens

### DIFF
--- a/components/activity/activityOverlay.tsx
+++ b/components/activity/activityOverlay.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated } from 'react-native';
 import { useAppTheme } from '../../hooks/useAppTheme';
 import { useEmoji } from '../../context/EmojiContext';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
   distance: number;
@@ -13,6 +14,7 @@ type Props = {
 export default function ActivityOverlay({ distance, timeFormatted, onEnd, disabled }: Props) {
   const theme = useAppTheme();
   const { emoji } = useEmoji();
+  const { t } = useTranslation();
   const scale = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -31,13 +33,13 @@ export default function ActivityOverlay({ distance, timeFormatted, onEnd, disabl
         <Animated.Text style={[styles.emoji, { transform: [{ scale }] }]}>{emoji}</Animated.Text>
         <Text style={styles.distance}>{distance.toFixed(2)} km</Text>
         <Text style={styles.time}>
-          Duração:
+          {t('activity.duration')}
           {timeFormatted}
         </Text>
       </View>
       <View style={styles.footer} pointerEvents="box-none">
         <TouchableOpacity style={styles.button} onPress={onEnd} disabled={disabled}>
-          <Text style={styles.buttonText}>FINALIZAR</Text>
+          <Text style={styles.buttonText}>{t('activity.finish')}</Text>
         </TouchableOpacity>
       </View>
     </>

--- a/components/activity/activitySummaryModal.tsx
+++ b/components/activity/activitySummaryModal.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useAppTheme } from '../../hooks/useAppTheme';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
   visible: boolean;
@@ -20,6 +21,7 @@ type Props = {
 
 export default function ActivitySummaryModal({ visible, summary, onClose }: Props) {
   const theme = useAppTheme();
+  const { t } = useTranslation();
   const styles = createStyles(theme);
   const navigation = useNavigation<any>();
   return (
@@ -32,7 +34,7 @@ export default function ActivitySummaryModal({ visible, summary, onClose }: Prop
       <View style={styles.modalBackground}>
         <View style={styles.modalContainer}>
           <ScrollView contentContainerStyle={styles.container}>
-            <Text style={styles.title}>Resumo da atividade:</Text>
+            <Text style={styles.title}>{t('activity.summaryTitle')}</Text>
             <Text style={styles.text}>{summary}</Text>
             <TouchableOpacity
               style={styles.button}
@@ -41,7 +43,7 @@ export default function ActivitySummaryModal({ visible, summary, onClose }: Prop
                 navigation.reset({ index: 0, routes: [{ name: 'MainTabs' }] });
               }}
             >
-              <Text style={styles.buttonText}>FECHAR</Text>
+              <Text style={styles.buttonText}>{t('activity.close')}</Text>
             </TouchableOpacity>
           </ScrollView>
         </View>

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1,4 +1,102 @@
 {
-  "welcome": "Bem-vindo",
-  "login": "Entrar"
+  "loginScreen": {
+    "welcome": "Bem-vindo",
+    "login": "Entrar"
+  },
+  "home": {
+    "greeting": "Olá, {{username}}!",
+    "start": "VAMOS COMEÇAR?",
+    "kilometers": "Kilômetros percorridos",
+    "discount": "Desconto obtido"
+  },
+  "activity": {
+    "autoStopTitle": "Atividade finalizada",
+    "autoStopMessage": "Detectamos que você está em um veículo. A atividade foi encerrada automaticamente.",
+    "loadingMap": "Carregando mapa...",
+    "loadingMapGeneric": "Carregando o mapa...",
+    "exitTitle": "Você está em uma atividade",
+    "exitQuestion": "Deseja encerrar ou salvar antes de sair?",
+    "saveAndExit": "Salvar e sair",
+    "cancel": "Cancelar",
+    "close": "FECHAR",
+    "summary": "🟢 Atividade completada\n\n📏 Distância: {{distance}} km\n⏱️ Duração: {{duration}}",
+    "finish": "FINALIZAR",
+    "duration": "Duração:",
+    "summaryTitle": "Resumo da atividade:"
+  },
+  "admin": {
+    "panel": "Painel Admin",
+    "searchPlaceholder": "Buscar por e-mail",
+    "search": "Buscar",
+    "emailRequired": "Digite um e-mail para buscar",
+    "userNotFound": "Usuário não encontrado",
+    "searchError": "Erro ao buscar dados",
+    "restricted": "Acesso restrito",
+    "activities": "Atividades: {{count}}",
+    "distance": "Distância: {{distance}} km",
+    "time": "Tempo: {{time}}"
+  },
+  "changePassword": {
+    "fillAll": "Preencha todos os campos",
+    "minLength": "A senha deve ter ao menos 6 caracteres",
+    "mismatch": "As senhas não coincidem",
+    "success": "Sucesso",
+    "updated": "Senha atualizada",
+    "error": "Erro ao atualizar",
+    "current": "Senha atual",
+    "new": "Nova senha",
+    "confirm": "Confirmar senha",
+    "save": "Salvar alterações"
+  },
+  "login": {
+    "title": "Saúde+",
+    "subtitle": "Entre para continuar",
+    "email": "E-mail",
+    "password": "Senha",
+    "fillAll": "Preencha todos os campos",
+    "invalidEmail": "Formato de e-mail inválido",
+    "minLength": "A senha deve ter no mínimo 6 caracteres",
+    "userNotFound": "Usuário não encontrado",
+    "loginError": "Erro ao fazer login, verifique seus dados",
+    "enter": "Entrar",
+    "registerLink": "Não tem conta? Criar uma"
+  },
+  "profile": {
+    "loading": "Cargando usuario...",
+    "chooseEmoji": "Escolher emoji de atividade",
+    "logout": "Sair"
+  },
+  "register": {
+    "title": "Criar conta",
+    "email": "E-mail",
+    "password": "Senha",
+    "fillAll": "Preencha todos os campos",
+    "invalidEmail": "Formato de e-mail inválido",
+    "minLength": "A senha deve ter no mínimo 6 caracteres",
+    "success": "Cadastro realizado com sucesso!",
+    "error": "Erro ao fazer registro, verifique seus dados",
+    "register": "Registrar-se",
+    "loginLink": "Já tem conta? Entrar"
+  },
+  "settings": {
+    "title": "Settings",
+    "darkMode": "Modo escuro",
+    "changePassword": "Mudar senha"
+  },
+  "splash": {
+    "title": "Saúde+",
+    "subtitle": "Transforme passos em economia",
+    "createAccount": "CRIAR CONTA",
+    "haveAccount": "JÁ POSSUO CONTA",
+    "footer": "© 2025 Saúde+. Todos os direitos reservados."
+  },
+  "stats": {
+    "title": "Registro de Actividades",
+    "invalidActivity": "Actividad no válida",
+    "status": {
+      "pending": "pendente",
+      "valid": "válida",
+      "invalid": "inválida"
+    }
+  }
 }

--- a/screens/Activity.tsx
+++ b/screens/Activity.tsx
@@ -29,6 +29,7 @@ import ActivityMap from '../components/activity/activityMap';
 import ActivityOverlay from '../components/activity/activityOverlay';
 import ActivitySummaryModal from '../components/activity/activitySummaryModal';
 import { useKilometers } from '../context/KmContext';
+import { useTranslation } from 'react-i18next';
 
 export default function Activity() {
   const {
@@ -53,6 +54,7 @@ export default function Activity() {
   const [activitySummary, setActivitySummary] = useState('');
   const [exitModalVisible, setExitModalVisible] = useState(false);
   const { theme } = useTheme();
+  const { t } = useTranslation();
 
   const handleSaveAndExit = async () => {
     await handleEndActivity();
@@ -77,7 +79,10 @@ export default function Activity() {
     setActivityEnded(true);
     await stopTracking();
 
-    const summary = `🟢 Actividad completada\n\n📏 Distancia: ${totalDistance.toFixed(2)} km\n⏱️ Duración: ${formatElapsedTime(elapsedTime)}`;
+    const summary = t('activity.summary', {
+      distance: totalDistance.toFixed(2),
+      duration: formatElapsedTime(elapsedTime),
+    });
     setActivitySummary(summary);
     setSummaryVisible(true);
 
@@ -163,8 +168,8 @@ export default function Activity() {
   useEffect(() => {
     if (location?.speed !== null && location?.speed !== undefined && location.speed > 6) {
       Alert.alert(
-        'Atividade finalizada',
-        'Detectamos que você está em um veículo. A atividade foi encerrada automaticamente.',
+        t('activity.autoStopTitle'),
+        t('activity.autoStopMessage'),
         [{ text: 'OK' }],
       );
       stopActivityWithoutSaving();
@@ -199,7 +204,7 @@ export default function Activity() {
       >
         <ActivityIndicator size="large" color="#0099ff" />
         <Text style={{ marginTop: 10, color: theme === 'dark' ? '#eee' : '#333' }}>
-          Carregando mapa...
+          {t('activity.loadingMap')}
         </Text>
       </View>
     );
@@ -239,7 +244,7 @@ export default function Activity() {
           }}
         >
           <ActivityIndicator size="large" color="#0099ff" />
-          <Text style={{ color: '#ccc', marginTop: 16 }}>Carregando o mapa...</Text>
+          <Text style={{ color: '#ccc', marginTop: 16 }}>{t('activity.loadingMapGeneric')}</Text>
         </View>
       )}
 
@@ -302,7 +307,7 @@ export default function Activity() {
                 marginBottom: 12,
               }}
             >
-              Você está em uma atividade
+              {t('activity.exitTitle')}
             </Text>
             <Text
               style={{
@@ -310,11 +315,11 @@ export default function Activity() {
                 color: theme === 'dark' ? '#aaa' : '#333',
               }}
             >
-              Deseja encerrar ou salvar antes de sair?
+              {t('activity.exitQuestion')}
             </Text>
             <View style={{ marginTop: 24 }}>
-              <Button title="Salvar e sair" color="#1d3557" onPress={handleSaveAndExit} />
-              <Button title="Cancelar" onPress={() => setExitModalVisible(false)} />
+              <Button title={t('activity.saveAndExit')} color="#1d3557" onPress={handleSaveAndExit} />
+              <Button title={t('activity.cancel')} onPress={() => setExitModalVisible(false)} />
             </View>
           </View>
         </View>

--- a/screens/AdminPanel.tsx
+++ b/screens/AdminPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useAppTheme } from '../hooks/useAppTheme';
+import { useTranslation } from 'react-i18next';
 import { useUser } from '../hooks/useUser';
 import { findUserByEmail, getUserRole } from '../services/userService';
 import { getUserActivitiesSummary, MonthlySummary } from '../services/activityService';
@@ -21,6 +22,7 @@ export default function AdminPanel() {
   const navigation = useNavigation<any>();
   const { user } = useUser();
   const theme = useAppTheme();
+  const { t } = useTranslation();
 
   const [role, setRole] = useState<string | null>(null);
   const [query, setQuery] = useState('');
@@ -51,19 +53,19 @@ export default function AdminPanel() {
   };
 
   const handleSearch = async () => {
-    if (!query) return Alert.alert('Atenção', 'Digite um e-mail para buscar');
+    if (!query) return Alert.alert(t('admin.panel'), t('admin.emailRequired'));
     try {
       setLoading(true);
       const found = await findUserByEmail(query);
       if (!found) {
-        Alert.alert('Usuário não encontrado');
+        Alert.alert(t('admin.userNotFound'));
         setSummary([]);
         return;
       }
       const data = await getUserActivitiesSummary(found.id);
       setSummary(data);
     } catch (e) {
-      Alert.alert('Erro ao buscar dados');
+      Alert.alert(t('admin.searchError'));
     } finally {
       setLoading(false);
     }
@@ -72,7 +74,7 @@ export default function AdminPanel() {
   if (role !== 'admin') {
     return (
       <SafeAreaView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <Text>Acesso restrito</Text>
+        <Text>{t('admin.restricted')}</Text>
       </SafeAreaView>
     );
   }
@@ -93,14 +95,14 @@ export default function AdminPanel() {
           <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
         </TouchableOpacity>
         <Text style={{ fontSize: 20, fontWeight: 'bold', color: theme.colors.text }}>
-          Painel Admin
+          {t('admin.panel')}
         </Text>
         <View style={{ width: 24 }} />
       </View>
 
       <View style={{ padding: 20 }}>
         <TextInput
-          placeholder="Buscar por e-mail"
+          placeholder={t('admin.searchPlaceholder')}
           placeholderTextColor={theme.colors.darkGray}
           value={query}
           onChangeText={setQuery}
@@ -118,7 +120,7 @@ export default function AdminPanel() {
           onPress={handleSearch}
           style={{ backgroundColor: theme.colors.primary, padding: 12, borderRadius: 6 }}
         >
-          <Text style={{ color: theme.colors.white, textAlign: 'center' }}>Buscar</Text>
+          <Text style={{ color: theme.colors.white, textAlign: 'center' }}>{t('admin.search')}</Text>
         </TouchableOpacity>
       </View>
       {loading ? (
@@ -136,9 +138,9 @@ export default function AdminPanel() {
               }}
             >
               <Text style={{ fontWeight: 'bold', color: theme.colors.text }}>{item.month}</Text>
-              <Text style={{ color: theme.colors.text }}>Atividades: {item.totalActivities}</Text>
-              <Text style={{ color: theme.colors.text }}>Distância: {item.totalDistance} km</Text>
-              <Text style={{ color: theme.colors.text }}>Tempo: {formatTime(item.totalTime)}</Text>
+              <Text style={{ color: theme.colors.text }}>{t('admin.activities', { count: item.totalActivities })}</Text>
+              <Text style={{ color: theme.colors.text }}>{t('admin.distance', { distance: item.totalDistance })}</Text>
+              <Text style={{ color: theme.colors.text }}>{t('admin.time', { time: formatTime(item.totalTime) })}</Text>
             </View>
           )}
         />

--- a/screens/ChangePassword.tsx
+++ b/screens/ChangePassword.tsx
@@ -5,6 +5,7 @@ import { auth } from '../firebase/firebase';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { useTheme } from '../context/ThemeContext';
+import { useTranslation } from 'react-i18next';
 
 export default function ChangePassword({ navigation }: any) {
   const [current, setCurrent] = useState('');
@@ -13,20 +14,21 @@ export default function ChangePassword({ navigation }: any) {
   const [error, setError] = useState('');
   const theme = useAppTheme();
   const { theme: mode } = useTheme();
+  const { t } = useTranslation();
   const styles = createStyles(theme, mode);
 
   const handleSave = async () => {
     setError('');
     if (!current || !newPass || !repeat) {
-      setError('Preencha todos os campos');
+      setError(t('changePassword.fillAll'));
       return;
     }
     if (newPass.length < 6) {
-      setError('A senha deve ter ao menos 6 caracteres');
+      setError(t('changePassword.minLength'));
       return;
     }
     if (newPass !== repeat) {
-      setError('As senhas não coincidem');
+      setError(t('changePassword.mismatch'));
       return;
     }
     try {
@@ -35,10 +37,10 @@ export default function ChangePassword({ navigation }: any) {
       const cred = EmailAuthProvider.credential(user.email, current);
       await reauthenticateWithCredential(user, cred);
       await updatePassword(user, newPass);
-      Alert.alert('Sucesso', 'Senha atualizada');
+      Alert.alert(t('changePassword.success'), t('changePassword.updated'));
       navigation.goBack();
     } catch (e: any) {
-      setError(e.message || 'Erro ao atualizar');
+      setError(e.message || t('changePassword.error'));
     }
   };
 
@@ -48,7 +50,7 @@ export default function ChangePassword({ navigation }: any) {
         <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
       </TouchableOpacity>
       <TextInput
-        placeholder="Senha atual"
+        placeholder={t('changePassword.current')}
         secureTextEntry
         placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
@@ -56,7 +58,7 @@ export default function ChangePassword({ navigation }: any) {
         onChangeText={setCurrent}
       />
       <TextInput
-        placeholder="Nova senha"
+        placeholder={t('changePassword.new')}
         secureTextEntry
         placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
@@ -64,7 +66,7 @@ export default function ChangePassword({ navigation }: any) {
         onChangeText={setNewPass}
       />
       <TextInput
-        placeholder="Confirmar senha"
+        placeholder={t('changePassword.confirm')}
         secureTextEntry
         placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
@@ -73,7 +75,7 @@ export default function ChangePassword({ navigation }: any) {
       />
       {error ? <Text style={styles.error}>{error}</Text> : null}
       <TouchableOpacity style={styles.button} onPress={handleSave}>
-        <Text style={styles.buttonText}>Salvar alterações</Text>
+        <Text style={styles.buttonText}>{t('changePassword.save')}</Text>
       </TouchableOpacity>
     </SafeAreaView>
   );

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -14,9 +14,11 @@ import { useAppTheme } from '../hooks/useAppTheme';
 import { usePendingActivities } from '../context/PendingActivitiesContext';
 import { auth } from '../firebase/firebase';
 import { useKilometers } from '../context/KmContext';
+import { useTranslation } from 'react-i18next';
 
 export default function Home({ navigation }: any) {
   const theme = useAppTheme();
+  const { t } = useTranslation();
   const { sync, logPending, pendingCount } = usePendingActivities();
   const { kilometers } = useKilometers();
   const scaleAnim = useRef(new Animated.Value(1)).current;
@@ -66,7 +68,7 @@ export default function Home({ navigation }: any) {
 
       {/* Header */}
       <View style={styles.header}>
-        <Text style={styles.greeting}>¡Hola, {username}!</Text>
+        <Text style={styles.greeting}>{t('home.greeting', { username })}</Text>
         <View style={styles.dateBadge}>
           <Ionicons name="calendar" size={16} color={theme.colors.primary} />
           <Text style={styles.dateText}>
@@ -80,7 +82,7 @@ export default function Home({ navigation }: any) {
       </View>
 
       <View style={styles.titleContainer}>
-        <Text style={styles.mainTitle}>¿VAMOS A COMENZAR?</Text>
+        <Text style={styles.mainTitle}>{t('home.start')}</Text>
       </View>
 
       {/* Centered Button */}
@@ -103,12 +105,12 @@ export default function Home({ navigation }: any) {
       <View style={styles.bottomSection}>
         <View style={styles.statsCard}>
           <View style={styles.statItem}>
-            <Text style={styles.statLabel}>Kilómetros recorridos</Text>
+            <Text style={styles.statLabel}>{t('home.kilometers')}</Text>
             <Text style={styles.statValue}>{kilometers.toFixed(1)} km</Text>
           </View>
           <View style={styles.divider} />
           <View style={styles.statItem}>
-            <Text style={styles.statLabel}>Descuento obtenido</Text>
+            <Text style={styles.statLabel}>{t('home.discount')}</Text>
             <Text style={styles.statValue}>R$ {discount.toFixed(2)}</Text>
           </View>
         </View>

--- a/screens/Login.tsx
+++ b/screens/Login.tsx
@@ -15,6 +15,7 @@ import { loginWithEmail } from '../services/authService';
 import { auth } from '../firebase/firebase';
 import { useTheme } from '../context/ThemeContext';
 import { useUser } from '../hooks/useUser';
+import { useTranslation } from 'react-i18next';
 
 export default function Login({ navigation }: any) {
   const [email, setEmail] = useState('');
@@ -25,6 +26,7 @@ export default function Login({ navigation }: any) {
   const theme = useAppTheme();
   const { theme: mode } = useTheme();
   const { user } = useUser();
+  const { t } = useTranslation();
   const styles = createStyles(theme, mode);
 
   useEffect(() => {
@@ -35,19 +37,19 @@ export default function Login({ navigation }: any) {
 
   const handleLogin = async () => {
     if (!email || !password) {
-      Alert.alert('Atenção', 'Preencha todos os campos');
+      Alert.alert(t('login.fillAll'));
       return;
     }
 
     const emailRegex = /.+@.+\..+/;
     if (!emailRegex.test(email)) {
-      setEmailError('Formato de e-mail inválido');
+      setEmailError(t('login.invalidEmail'));
       return;
     }
     setEmailError('');
 
     if (password.length < 6) {
-      setPasswordError('A senha deve ter no mínimo 6 caracteres');
+      setPasswordError(t('login.minLength'));
       return;
     }
     setPasswordError('');
@@ -58,9 +60,9 @@ export default function Login({ navigation }: any) {
       navigation.replace('MainTabs');
     } catch (error: any) {
       if (error.code === 'auth/user-not-found') {
-        Alert.alert('Usuário não encontrado');
+        Alert.alert(t('login.userNotFound'));
       } else {
-        Alert.alert('Erro ao fazer login, verifique seus dados');
+        Alert.alert(t('login.loginError'));
       }
     } finally {
       setLoading(false);
@@ -69,11 +71,11 @@ export default function Login({ navigation }: any) {
 
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.logo}>Saúde+</Text>
-      <Text style={styles.subtitle}>Entre para continuar</Text>
+      <Text style={styles.logo}>{t('login.title')}</Text>
+      <Text style={styles.subtitle}>{t('login.subtitle')}</Text>
 
       <TextInput
-        placeholder="E-mail"
+        placeholder={t('login.email')}
         placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
         keyboardType="email-address"
@@ -83,7 +85,7 @@ export default function Login({ navigation }: any) {
       />
       {emailError ? <Text style={styles.error}>{emailError}</Text> : null}
       <TextInput
-        placeholder="Senha"
+        placeholder={t('login.password')}
         placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
         secureTextEntry
@@ -96,12 +98,12 @@ export default function Login({ navigation }: any) {
         {loading ? (
           <ActivityIndicator color={theme.colors.white} />
         ) : (
-          <Text style={styles.loginText}>Entrar</Text>
+          <Text style={styles.loginText}>{t('login.enter')}</Text>
         )}
       </TouchableOpacity>
 
       <TouchableOpacity onPress={() => navigation.navigate('Register')}>
-        <Text style={styles.registerLink}>Não tem conta? Criar uma</Text>
+        <Text style={styles.registerLink}>{t('login.registerLink')}</Text>
       </TouchableOpacity>
     </SafeAreaView>
   );

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -11,8 +11,8 @@ export default function LoginScreen() {
 
   return (
     <View>
-      <Text>{t('welcome')}</Text>
-      <Button title={t('login')} onPress={handleLogin} />
+      <Text>{t('loginScreen.welcome')}</Text>
+      <Button title={t('loginScreen.login')} onPress={handleLogin} />
     </View>
   );
 }

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -8,12 +8,14 @@ import { useUser } from '../hooks/useUser';
 import { useEmoji } from '../context/EmojiContext';
 import { auth } from '../firebase/firebase';
 import { log } from '../utils/logger';
+import { useTranslation } from 'react-i18next';
 
 export default function Profile() {
   const navigation = useNavigation<any>();
   const { user: authUser, authInitialized } = useUser();
   const { emoji, setEmoji } = useEmoji();
   const theme = useAppTheme();
+  const { t } = useTranslation();
   const [modalVisible, setModalVisible] = React.useState(false);
   const styles = StyleSheet.create({
     container: {
@@ -93,7 +95,7 @@ export default function Profile() {
           <Text style={styles.emojiAvatar}>{emoji}</Text>
         </View>
         {!authInitialized ? (
-          <Text style={styles.email}>Cargando usuario...</Text>
+          <Text style={styles.email}>{t('profile.loading')}</Text>
         ) : (
           <Text style={styles.email}>{authUser?.email}</Text>
         )}
@@ -110,7 +112,7 @@ export default function Profile() {
           onPress={() => setModalVisible(true)}
         >
           <Text style={[styles.logoutText, { color: theme.colors.primary }]}>
-            Escolher emoji de atividade
+            {t('profile.chooseEmoji')}
           </Text>
         </TouchableOpacity>
 
@@ -118,7 +120,7 @@ export default function Profile() {
         <View style={{ height: 24 }} />
 
         <TouchableOpacity onPress={handleLogout} style={styles.logoutButton}>
-          <Text style={styles.logoutText}>Sair</Text>
+          <Text style={styles.logoutText}>{t('profile.logout')}</Text>
         </TouchableOpacity>
       </View>
 

--- a/screens/Register.tsx
+++ b/screens/Register.tsx
@@ -14,6 +14,7 @@ import { useAppTheme } from '../hooks/useAppTheme';
 import { registerWithEmail } from '../services/authService';
 import { useTheme } from '../context/ThemeContext';
 import { useUser } from '../hooks/useUser';
+import { useTranslation } from 'react-i18next';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../types'; // Ajustá el path si está en otro lado
@@ -23,6 +24,7 @@ export default function Register() {
   const theme = useAppTheme();
   const { theme: mode } = useTheme();
   const { user } = useUser();
+  const { t } = useTranslation();
   const styles = createStyles(theme, mode);
 
   const [email, setEmail] = useState('');
@@ -42,19 +44,19 @@ export default function Register() {
 
   const handleRegister = async () => {
     if (!email || !password) {
-      Alert.alert('Atenção', 'Preencha todos os campos');
+      Alert.alert(t('register.fillAll'));
       return;
     }
 
     const emailRegex = /.+@.+\..+/;
     if (!emailRegex.test(email)) {
-      setEmailError('Formato de e-mail inválido');
+      setEmailError(t('register.invalidEmail'));
       return;
     }
     setEmailError('');
 
     if (password.length < 6) {
-      setPasswordError('A senha deve ter no mínimo 6 caracteres');
+      setPasswordError(t('register.minLength'));
       return;
     }
     setPasswordError('');
@@ -62,10 +64,10 @@ export default function Register() {
     try {
       setLoading(true);
       await registerWithEmail(email, password);
-      Alert.alert('Cadastro realizado com sucesso!');
+      Alert.alert(t('register.success'));
       navigation.goBack();
     } catch (error: any) {
-      Alert.alert('Erro ao fazer registro, verifique seus dados');
+      Alert.alert(t('register.error'));
     } finally {
       setLoading(false);
     }
@@ -77,10 +79,10 @@ export default function Register() {
         <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
       </TouchableOpacity>
 
-      <Text style={styles.title}>Criar conta</Text>
+      <Text style={styles.title}>{t('register.title')}</Text>
 
       <TextInput
-        placeholder="E-mail"
+        placeholder={t('register.email')}
         placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
         keyboardType="email-address"
@@ -91,7 +93,7 @@ export default function Register() {
       {emailError ? <Text style={styles.error}>{emailError}</Text> : null}
 
       <TextInput
-        placeholder="Senha"
+        placeholder={t('register.password')}
         placeholderTextColor={mode === 'dark' ? '#aaa' : '#666'}
         style={styles.input}
         secureTextEntry
@@ -104,12 +106,12 @@ export default function Register() {
         {loading ? (
           <ActivityIndicator color={theme.colors.white} />
         ) : (
-          <Text style={styles.buttonText}>Registrar-se</Text>
+          <Text style={styles.buttonText}>{t('register.register')}</Text>
         )}
       </TouchableOpacity>
 
       <TouchableOpacity onPress={() => navigation.goBack()}>
-        <Text style={styles.loginLink}>Já tem conta? Entrar</Text>
+        <Text style={styles.loginLink}>{t('register.loginLink')}</Text>
       </TouchableOpacity>
     </SafeAreaView>
   );

--- a/screens/Settings.tsx
+++ b/screens/Settings.tsx
@@ -12,11 +12,13 @@ import { useNavigation } from '@react-navigation/native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useTheme } from '../context/ThemeContext';
 import { useAppTheme } from '../hooks/useAppTheme';
+import { useTranslation } from 'react-i18next';
 
 export default function Settings() {
   const navigation = useNavigation<any>();
   const { theme, toggleTheme } = useTheme();
   const appTheme = useAppTheme();
+  const { t } = useTranslation();
   const styles = StyleSheet.create({
     container: {
       flex: 1,
@@ -56,19 +58,19 @@ export default function Settings() {
             color: theme === 'dark' ? '#fff' : '#000',
           }}
         >
-          Settings
+          {t('settings.title')}
         </Text>
         <View style={{ width: 24 }} />
       </View>
       <View style={styles.settingItem}>
-        <Text style={styles.label}>Modo escuro</Text>
+        <Text style={styles.label}>{t('settings.darkMode')}</Text>
         <Switch value={theme === 'dark'} onValueChange={toggleTheme} />
       </View>
       <TouchableOpacity
         style={styles.settingItem}
         onPress={() => navigation.navigate('ChangePassword')}
       >
-        <Text style={styles.link}>Mudar senha</Text>
+        <Text style={styles.link}>{t('settings.changePassword')}</Text>
       </TouchableOpacity>
     </SafeAreaView>
   );

--- a/screens/Splash.tsx
+++ b/screens/Splash.tsx
@@ -3,11 +3,13 @@ import { Text, StyleSheet, TouchableOpacity, SafeAreaView } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { useUser } from '../hooks/useUser';
+import { useTranslation } from 'react-i18next';
 
 export default function SplashScreen() {
   const navigation = useNavigation<any>();
   const { user } = useUser();
   const theme = useAppTheme();
+  const { t } = useTranslation();
   const styles = createStyles(theme);
 
   useEffect(() => {
@@ -18,21 +20,21 @@ export default function SplashScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>Saúde+</Text>
-      <Text style={styles.subtitle}>Transforme passos em economia</Text>
+      <Text style={styles.title}>{t('splash.title')}</Text>
+      <Text style={styles.subtitle}>{t('splash.subtitle')}</Text>
 
       <TouchableOpacity
         style={styles.primaryButton}
         onPress={() => navigation.navigate('Register')}
       >
-        <Text style={styles.primaryButtonText}>CRIAR CONTA</Text>
+        <Text style={styles.primaryButtonText}>{t('splash.createAccount')}</Text>
       </TouchableOpacity>
 
       <TouchableOpacity style={styles.secondaryButton} onPress={() => navigation.navigate('Login')}>
-        <Text style={styles.secondaryButtonText}>JÁ POSSUO CONTA</Text>
+        <Text style={styles.secondaryButtonText}>{t('splash.haveAccount')}</Text>
       </TouchableOpacity>
 
-      <Text style={styles.footer}>© 2025 Saúde+. Todos os direitos reservados.</Text>
+      <Text style={styles.footer}>{t('splash.footer')}</Text>
     </SafeAreaView>
   );
 }

--- a/screens/Stats.tsx
+++ b/screens/Stats.tsx
@@ -14,12 +14,14 @@ import { useAppTheme } from '../hooks/useAppTheme';
 import { useUser } from '../hooks/useUser';
 import { getActivitiesByUser } from '../services/activityService';
 import { log } from '../utils/logger';
+import { useTranslation } from 'react-i18next';
 
 export default function Stats() {
   const { user, authInitialized } = useUser();
   const [activities, setActivities] = useState<any[]>([]);
   const [loadingActivities, setLoadingActivities] = useState(true);
   const theme = useAppTheme();
+  const { t } = useTranslation();
   const styles = createStyles(theme);
 
   useEffect(() => {
@@ -58,13 +60,13 @@ export default function Stats() {
       const durationSec = item.duration % 60;
       const distance = item.distance ? item.distance.toFixed(2) : '0.00';
 
-      let statusText = 'pendente';
+      let statusText = t('stats.status.pending');
       let statusColor = '#e67e22';
       if (item.status === 'valida') {
-        statusText = 'válida';
+        statusText = t('stats.status.valid');
         statusColor = '#2ecc71';
       } else if (item.status === 'invalida') {
-        statusText = 'inválida';
+        statusText = t('stats.status.invalid');
         statusColor = '#e74c3c';
       }
 
@@ -83,7 +85,7 @@ export default function Stats() {
       log('screens/Stats.tsx', 'renderActivity', 'ERROR', `Error rendering activity: ${error}`);
       return (
         <View style={styles.activityCard}>
-          <Text style={styles.activityTitle}>Actividad no válida</Text>
+          <Text style={styles.activityTitle}>{t('stats.invalidActivity')}</Text>
         </View>
       );
     }
@@ -92,7 +94,7 @@ export default function Stats() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.title}>Registro de Actividades</Text>
+        <Text style={styles.title}>{t('stats.title')}</Text>
         <View style={{ width: 24 }} />
       </View>
 


### PR DESCRIPTION
## Summary
- replace hardcoded text across all screens with `t()`
- group translation keys in `locales/pt.json`
- update activity components for translations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68703f852acc83228cd1de9e2b915958