### PR TITLE
Migrate Spanish UI strings to i18n

### DIFF
--- a/components/activity/activityOverlay.tsx
+++ b/components/activity/activityOverlay.tsx
@@ -31,15 +31,17 @@ export default function ActivityOverlay({ distance, timeFormatted, onEnd, disabl
     <>
       <View style={styles.header}>
         <Animated.Text style={[styles.emoji, { transform: [{ scale }] }]}>{emoji}</Animated.Text>
-        <Text style={styles.distance}>{distance.toFixed(2)} km</Text>
+        <Text style={styles.distance}>
+          {t('activity.distance', { distance: distance.toFixed(2) })}
+        </Text>
         <Text style={styles.time}>
-          {t('activity.duration')}
+          {t('activity.durationLabel')}
           {timeFormatted}
         </Text>
       </View>
       <View style={styles.footer} pointerEvents="box-none">
         <TouchableOpacity style={styles.button} onPress={onEnd} disabled={disabled}>
-          <Text style={styles.buttonText}>{t('activity.finish')}</Text>
+          <Text style={styles.buttonText}>{t('activity.finishButton')}</Text>
         </TouchableOpacity>
       </View>
     </>

--- a/components/home/HeaderInfo.tsx
+++ b/components/home/HeaderInfo.tsx
@@ -8,12 +8,12 @@ interface Props {
 
 export default function HeaderInfo({ date }: Props) {
   const theme = useAppTheme();
-  const formatted = date
-    .toLocaleDateString('es-ES', {
-      weekday: 'long',
-      day: 'numeric',
-      month: 'long',
-    })
+  const formatted = new Intl.DateTimeFormat('pt', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  })
+    .format(date)
     .replace(/^\w/, (m) => m.toUpperCase());
   return <Text style={[styles.text, { color: theme.colors.darkGray }]}>{formatted}</Text>;
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -10,6 +10,16 @@
     "discount": "Desconto obtido"
   },
   "activity": {
+    "title": "Registro de Atividades",
+    "finishButton": "Finalizar",
+    "status": {
+      "pending": "pendente",
+      "valid": "válida",
+      "invalid": "inválida"
+    },
+    "duration": "{{minutes}} min {{seconds}} seg",
+    "distance": "{{distance}} km",
+    "date": "{{day}} {{date}} de {{month}} de {{year}}",
     "autoStopTitle": "Atividade finalizada",
     "autoStopMessage": "Detectamos que você está em um veículo. A atividade foi encerrada automaticamente.",
     "loadingMap": "Carregando mapa...",
@@ -20,8 +30,7 @@
     "cancel": "Cancelar",
     "close": "FECHAR",
     "summary": "🟢 Atividade completada\n\n📏 Distância: {{distance}} km\n⏱️ Duração: {{duration}}",
-    "finish": "FINALIZAR",
-    "duration": "Duração:",
+    "durationLabel": "Duração:",
     "summaryTitle": "Resumo da atividade:"
   },
   "admin": {
@@ -62,7 +71,7 @@
     "registerLink": "Não tem conta? Criar uma"
   },
   "profile": {
-    "loading": "Cargando usuario...",
+    "loading": "Carregando usuário...",
     "chooseEmoji": "Escolher emoji de atividade",
     "logout": "Sair"
   },
@@ -91,12 +100,6 @@
     "footer": "© 2025 Saúde+. Todos os direitos reservados."
   },
   "stats": {
-    "title": "Registro de Actividades",
-    "invalidActivity": "Actividad no válida",
-    "status": {
-      "pending": "pendente",
-      "valid": "válida",
-      "invalid": "inválida"
-    }
+    "invalidActivity": "Atividade inválida"
   }
 }

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -72,11 +72,12 @@ export default function Home({ navigation }: any) {
         <View style={styles.dateBadge}>
           <Ionicons name="calendar" size={16} color={theme.colors.primary} />
           <Text style={styles.dateText}>
-            {new Date().toLocaleDateString('es-ES', {
+            {new Intl.DateTimeFormat('pt', {
               weekday: 'short',
               day: 'numeric',
               month: 'short',
-            })}
+            })
+              .format(new Date())}
           </Text>
         </View>
       </View>
@@ -106,7 +107,9 @@ export default function Home({ navigation }: any) {
         <View style={styles.statsCard}>
           <View style={styles.statItem}>
             <Text style={styles.statLabel}>{t('home.kilometers')}</Text>
-            <Text style={styles.statValue}>{kilometers.toFixed(1)} km</Text>
+            <Text style={styles.statValue}>
+              {t('activity.distance', { distance: kilometers.toFixed(1) })}
+            </Text>
           </View>
           <View style={styles.divider} />
           <View style={styles.statItem}>

--- a/screens/Stats.tsx
+++ b/screens/Stats.tsx
@@ -50,23 +50,29 @@ export default function Stats() {
           ? new Date(item.date.seconds * 1000)
           : new Date(item.date);
 
-      const formattedDate = format(
-        activityDate,
-        "eeee d 'de' MMMM 'de' yyyy",
-      );
+      const weekday = new Intl.DateTimeFormat('pt', { weekday: 'long' }).format(activityDate);
+      const month = new Intl.DateTimeFormat('pt', { month: 'long' }).format(activityDate);
+      const day = activityDate.getDate();
+      const year = activityDate.getFullYear();
+      const formattedDate = t('activity.date', {
+        day: weekday,
+        date: day,
+        month,
+        year,
+      });
       const formattedTime = format(activityDate, 'HH:mm');
 
       const durationMin = Math.floor(item.duration / 60);
       const durationSec = item.duration % 60;
       const distance = item.distance ? item.distance.toFixed(2) : '0.00';
 
-      let statusText = t('stats.status.pending');
+      let statusText = t('activity.status.pending');
       let statusColor = '#e67e22';
       if (item.status === 'valida') {
-        statusText = t('stats.status.valid');
+        statusText = t('activity.status.valid');
         statusColor = '#2ecc71';
       } else if (item.status === 'invalida') {
-        statusText = t('stats.status.invalid');
+        statusText = t('activity.status.invalid');
         statusColor = '#e74c3c';
       }
 
@@ -75,9 +81,9 @@ export default function Stats() {
           <Text style={styles.activityTitle}>📆 {formattedDate}</Text>
           <Text style={styles.activityInfo}>🕒 {formattedTime}</Text>
           <Text style={styles.activityInfo}>
-            ⏱️ {durationMin} min {durationSec} seg
+            ⏱️ {t('activity.duration', { minutes: durationMin, seconds: durationSec })}
           </Text>
-          <Text style={styles.activityInfo}>📏 {distance} km</Text>
+          <Text style={styles.activityInfo}>📏 {t('activity.distance', { distance })}</Text>
           <Text style={[styles.activityInfo, { color: statusColor }]}>✅ {statusText}</Text>
         </View>
       );
@@ -94,7 +100,7 @@ export default function Stats() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.title}>{t('stats.title')}</Text>
+        <Text style={styles.title}>{t('activity.title')}</Text>
         <View style={{ width: 24 }} />
       </View>
 
@@ -114,58 +120,59 @@ export default function Stats() {
   );
 }
 
-const createStyles = (theme: any) => StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: theme.colors.background,
-    paddingTop: 40,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: 15,
-    backgroundColor: theme.colors.background,
-  },
-  title: {
-    flex: 1,
-    textAlign: 'center',
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: theme.colors.text,
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: theme.colors.background,
-  },
-  listContent: {
-    paddingBottom: 60,
-    backgroundColor: theme.colors.background,
-  },
-  activityCard: {
-    backgroundColor: theme.colors.cardBackground || 
-                   (theme.colors.background === '#121212' ? '#1e1e1e' : '#fff'),
-    borderRadius: 12,
-    padding: 16,
-    marginHorizontal: 16,
-    marginVertical: 8,
-    elevation: 1,
-    shadowColor: theme.colors.shadow || '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.05,
-    shadowRadius: 3,
-  },
-  activityTitle: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    marginBottom: 6,
-    color: theme.colors.text,
-  },
-  activityInfo: {
-    fontSize: 14,
-    color: theme.colors.text,
-    marginBottom: 2,
-    opacity: 0.9,
-  },
-});
+const createStyles = (theme: any) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+      paddingTop: 40,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 15,
+      backgroundColor: theme.colors.background,
+    },
+    title: {
+      flex: 1,
+      textAlign: 'center',
+      fontSize: 16,
+      fontWeight: 'bold',
+      color: theme.colors.text,
+    },
+    loadingContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: theme.colors.background,
+    },
+    listContent: {
+      paddingBottom: 60,
+      backgroundColor: theme.colors.background,
+    },
+    activityCard: {
+      backgroundColor:
+        theme.colors.cardBackground || (theme.colors.background === '#121212' ? '#1e1e1e' : '#fff'),
+      borderRadius: 12,
+      padding: 16,
+      marginHorizontal: 16,
+      marginVertical: 8,
+      elevation: 1,
+      shadowColor: theme.colors.shadow || '#000',
+      shadowOffset: { width: 0, height: 1 },
+      shadowOpacity: 0.05,
+      shadowRadius: 3,
+    },
+    activityTitle: {
+      fontSize: 16,
+      fontWeight: 'bold',
+      marginBottom: 6,
+      color: theme.colors.text,
+    },
+    activityInfo: {
+      fontSize: 14,
+      color: theme.colors.text,
+      marginBottom: 2,
+      opacity: 0.9,
+    },
+  });


### PR DESCRIPTION
## Summary
- internationalize activity overlay
- use translation keys in stats screen and improve date formatting
- localize date labels on home screen
- update header date component
- reorganize Portuguese locale file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68704c756874832295496aa65bbfab2a