### PR TITLE
Implement anti-cheat hooks and flags

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ import { ThemeProvider } from './context/ThemeContext';
 import { EmojiProvider } from './context/EmojiContext';
 import { PendingActivityProvider } from './context/PendingActivitiesContext';
 import { KmProvider } from './context/KmContext';
+import { ActivityProvider } from './context/ActivityContext';
 import { useUser } from './hooks/useUser';
 import useGlobalNetwork from './hooks/useGlobalNetwork';
 import useActivitySync from './hooks/useActivitySync';
@@ -50,27 +51,29 @@ export default function App() {
     <ThemeProvider>
       <EmojiProvider>
         <PendingActivityProvider>
-          <KmProvider>
-            <NavigationContainer>
-              <Stack.Navigator
-                initialRouteName={initialRoute}
-                screenOptions={{
-                  headerShown: false,
-                  animation: 'fade_from_bottom',
-                  gestureEnabled: true,
-                }}
-              >
-                <Stack.Screen name="Splash" component={Splash} />
-                <Stack.Screen name="Login" component={Login} />
-                <Stack.Screen name="Register" component={Register} />
-                <Stack.Screen name="MainTabs" component={MainTabs} />
-                <Stack.Screen name="Activity" component={Activity} />
-                <Stack.Screen name="Settings" component={Settings} />
-                <Stack.Screen name="ChangePassword" component={ChangePassword} />
-                <Stack.Screen name="AdminPanel" component={AdminPanel} />
-              </Stack.Navigator>
-            </NavigationContainer>
-          </KmProvider>
+          <ActivityProvider>
+            <KmProvider>
+              <NavigationContainer>
+                <Stack.Navigator
+                  initialRouteName={initialRoute}
+                  screenOptions={{
+                    headerShown: false,
+                    animation: 'fade_from_bottom',
+                    gestureEnabled: true,
+                  }}
+                >
+                  <Stack.Screen name="Splash" component={Splash} />
+                  <Stack.Screen name="Login" component={Login} />
+                  <Stack.Screen name="Register" component={Register} />
+                  <Stack.Screen name="MainTabs" component={MainTabs} />
+                  <Stack.Screen name="Activity" component={Activity} />
+                  <Stack.Screen name="Settings" component={Settings} />
+                  <Stack.Screen name="ChangePassword" component={ChangePassword} />
+                  <Stack.Screen name="AdminPanel" component={AdminPanel} />
+                </Stack.Navigator>
+              </NavigationContainer>
+            </KmProvider>
+          </ActivityProvider>
         </PendingActivityProvider>
       </EmojiProvider>
     </ThemeProvider>

--- a/context/ActivityContext.tsx
+++ b/context/ActivityContext.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export interface SuspiciousFlags {
+  biometricsRejected: boolean;
+  speedTooHigh: boolean;
+  noWalkingPattern: boolean;
+  gpsInactive: boolean;
+  inactiveTimeout: boolean;
+}
+
+interface ActivityCtx {
+  suspiciousFlags: SuspiciousFlags;
+  setFlag: (flag: keyof SuspiciousFlags, value: boolean) => void;
+  resetFlags: () => void;
+}
+
+const defaultFlags: SuspiciousFlags = {
+  biometricsRejected: false,
+  speedTooHigh: false,
+  noWalkingPattern: false,
+  gpsInactive: false,
+  inactiveTimeout: false,
+};
+
+const ActivityContext = createContext<ActivityCtx>({
+  suspiciousFlags: defaultFlags,
+  setFlag: () => {},
+  resetFlags: () => {},
+});
+
+export const ActivityProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [suspiciousFlags, setSuspiciousFlags] = useState<SuspiciousFlags>(defaultFlags);
+
+  const setFlag = (flag: keyof SuspiciousFlags, value: boolean) =>
+    setSuspiciousFlags((prev) => ({ ...prev, [flag]: value }));
+
+  const resetFlags = () => setSuspiciousFlags(defaultFlags);
+
+  return (
+    <ActivityContext.Provider value={{ suspiciousFlags, setFlag, resetFlags }}>
+      {children}
+    </ActivityContext.Provider>
+  );
+};
+
+export const useActivityFlags = () => useContext(ActivityContext);

--- a/hooks/useInactivityTimeout.ts
+++ b/hooks/useInactivityTimeout.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import type { LocationObjectCoords } from 'expo-location';
+
+/**
+ * Monitors lack of movement (no GPS change or accelerometer movement) and
+ * triggers a callback after a period of inactivity.
+ */
+export default function useInactivityTimeout(
+  location: LocationObjectCoords | null,
+  activeMovement: boolean,
+  onTimeout: () => void,
+  timeoutMs = 5 * 60 * 1000,
+) {
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const lastPosRef = useRef<LocationObjectCoords | null>(null);
+
+  const resetTimer = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(onTimeout, timeoutMs);
+  };
+
+  useEffect(() => {
+    resetTimer();
+  }, [activeMovement, location?.latitude, location?.longitude]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!location) return;
+    if (
+      !lastPosRef.current ||
+      lastPosRef.current.latitude !== location.latitude ||
+      lastPosRef.current.longitude !== location.longitude
+    ) {
+      lastPosRef.current = location;
+    }
+  }, [location]);
+}

--- a/hooks/useSpeedValidation.ts
+++ b/hooks/useSpeedValidation.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Placeholder hook to validate the user speed while tracking.
+ * It calculates an average from the last few samples and marks the
+ * activity as suspicious when it stays above 15 km/h.
+ */
+export default function useSpeedValidation(speed: number | null) {
+  // speed parameter is expected in meters/second
+  const [speedTooHigh, setSpeedTooHigh] = useState(false);
+  const samplesRef = useRef<number[]>([]);
+
+  useEffect(() => {
+    if (speed == null) return;
+    samplesRef.current.push(speed);
+    if (samplesRef.current.length > 5) samplesRef.current.shift();
+
+    const avg = samplesRef.current.reduce((acc, v) => acc + v, 0) / samplesRef.current.length;
+    // 15 km/h -> 4.1666 m/s
+    setSpeedTooHigh(avg > 15 / 3.6);
+  }, [speed]);
+
+  return { speedTooHigh };
+}

--- a/hooks/useWalkingPattern.ts
+++ b/hooks/useWalkingPattern.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Placeholder hook that should analyse accelerometer data to determine
+ * if the user is actually walking. Without the real sensor libraries
+ * we simply expose the state and an updater for future integration.
+ */
+export default function useWalkingPattern() {
+  const [noWalkingPattern, setNoWalkingPattern] = useState(false);
+  const oscillationRef = useRef<number[]>([]);
+
+  // Placeholder effect. In a real implementation this would subscribe to the
+  // accelerometer and analyse the oscillation pattern. For now we simply keep
+  // the API ready.
+  useEffect(() => {
+    // TODO: integrate with Accelerometer from expo-sensors
+    return () => {
+      oscillationRef.current = [];
+    };
+  }, []);
+
+  return { noWalkingPattern, setNoWalkingPattern };
+}

--- a/screens/Activity.tsx
+++ b/screens/Activity.tsx
@@ -22,6 +22,11 @@ import { log } from '../utils/logger';
 import { evaluateActivityStatus } from '../utils/stats';
 
 import useTracking from '../hooks/useTracking';
+import useSpeedValidation from '../hooks/useSpeedValidation';
+import useWalkingPattern from '../hooks/useWalkingPattern';
+import useInactivityTimeout from '../hooks/useInactivityTimeout';
+import { useActivityFlags } from '../context/ActivityContext';
+import { requestBiometricValidation } from '../services/antiCheat';
 
 import { usePendingActivities } from '../context/PendingActivitiesContext';
 
@@ -41,6 +46,7 @@ export default function Activity() {
     stopTracking,
     formatElapsedTime,
     startTime,
+    gpsLost,
   } = useTracking();
 
   const mapRef = useRef<MapView>(null);
@@ -55,6 +61,13 @@ export default function Activity() {
   const [exitModalVisible, setExitModalVisible] = useState(false);
   const { theme } = useTheme();
   const { t } = useTranslation();
+  const { setFlag } = useActivityFlags();
+  const { speedTooHigh } = useSpeedValidation(location?.speed ?? null);
+  const { noWalkingPattern, setNoWalkingPattern } = useWalkingPattern();
+  useInactivityTimeout(location ?? null, !noWalkingPattern, () => {
+    setFlag('inactiveTimeout', true);
+    handleEndActivity();
+  });
 
   const handleSaveAndExit = async () => {
     await handleEndActivity();
@@ -76,6 +89,13 @@ export default function Activity() {
   const handleEndActivity = async () => {
     if (activityEnded) return;
 
+    const ok = await requestBiometricValidation();
+    if (!ok) {
+      setFlag('biometricsRejected', true);
+      Alert.alert('Biometría requerida');
+      return;
+    }
+
     setActivityEnded(true);
     await stopTracking();
 
@@ -87,7 +107,12 @@ export default function Activity() {
     setSummaryVisible(true);
 
     if (!startTime) {
-      log('screens/Activity.tsx', 'handleEndActivity', 'ACTIVITY', 'No se puede guardar actividad: startTime es null');
+      log(
+        'screens/Activity.tsx',
+        'handleEndActivity',
+        'ACTIVITY',
+        'No se puede guardar actividad: startTime es null',
+      );
       return;
     }
     const end = new Date();
@@ -95,7 +120,12 @@ export default function Activity() {
     const rawConnection =
       net.isConnected && net.isInternetReachable !== false ? net.type || 'unknown' : 'offline';
 
-    const conexion = rawConnection === 'wifi' ? 'wifi' : rawConnection === 'cellular' ? 'datos_moviles' : 'offline';
+    const conexion =
+      rawConnection === 'wifi'
+        ? 'wifi'
+        : rawConnection === 'cellular'
+          ? 'datos_moviles'
+          : 'offline';
     const metodoGuardado = conexion === 'offline' ? 'offline_post_sync' : 'online';
 
     const { status, invalidReason, velocidadPromedio } = evaluateActivityStatus(
@@ -145,19 +175,45 @@ export default function Activity() {
       const state = await NetInfo.fetch();
       const connected = Boolean(state.isConnected);
       prev = connected;
-      log('screens/Activity.tsx', 'checkInitial', 'NETWORK', connected ? 'Conectado' : 'Sin conexión');
+      log(
+        'screens/Activity.tsx',
+        'checkInitial',
+        'NETWORK',
+        connected ? 'Conectado' : 'Sin conexión',
+      );
       if (connected) {
         sync();
       }
     };
     checkInitial();
 
-    startTracking();
+    const init = async () => {
+      const ok = await requestBiometricValidation();
+      if (!ok) {
+        setFlag('biometricsRejected', true);
+        navigation.goBack();
+        return;
+      }
+      startTracking();
+    };
+    init();
 
     return () => {
       stopTracking();
     };
   }, []);
+
+  useEffect(() => {
+    setFlag('speedTooHigh', speedTooHigh);
+  }, [speedTooHigh]);
+
+  useEffect(() => {
+    setFlag('noWalkingPattern', noWalkingPattern);
+  }, [noWalkingPattern]);
+
+  useEffect(() => {
+    setFlag('gpsInactive', gpsLost);
+  }, [gpsLost]);
 
   useEffect(() => {
     if (location) {
@@ -167,11 +223,7 @@ export default function Activity() {
 
   useEffect(() => {
     if (location?.speed !== null && location?.speed !== undefined && location.speed > 6) {
-      Alert.alert(
-        t('activity.autoStopTitle'),
-        t('activity.autoStopMessage'),
-        [{ text: 'OK' }],
-      );
+      Alert.alert(t('activity.autoStopTitle'), t('activity.autoStopMessage'), [{ text: 'OK' }]);
       stopActivityWithoutSaving();
     }
   }, [location?.speed]);
@@ -318,7 +370,11 @@ export default function Activity() {
               {t('activity.exitQuestion')}
             </Text>
             <View style={{ marginTop: 24 }}>
-              <Button title={t('activity.saveAndExit')} color="#1d3557" onPress={handleSaveAndExit} />
+              <Button
+                title={t('activity.saveAndExit')}
+                color="#1d3557"
+                onPress={handleSaveAndExit}
+              />
               <Button title={t('activity.cancel')} onPress={() => setExitModalVisible(false)} />
             </View>
           </View>

--- a/services/antiCheat.ts
+++ b/services/antiCheat.ts
@@ -1,0 +1,9 @@
+/**
+ * Placeholder utilities for anti-cheat features.
+ * The real implementations will integrate with biometric and sensor libraries.
+ */
+
+export async function requestBiometricValidation(): Promise<boolean> {
+  // TODO: integrate with expo-local-authentication or similar
+  return true;
+}


### PR DESCRIPTION
## Summary
- add ActivityContext with suspicious flags
- implement speed validation, walking pattern and inactivity hooks
- add biometric validation placeholder
- integrate anti-cheat hooks into Activity screen
- wrap app with ActivityProvider

## Testing
- `npm test`
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68711e8268d483229ed66b0d030fb0c0