### PR TITLE
Implement biometric authentication

### DIFF
--- a/screens/Activity.tsx
+++ b/screens/Activity.tsx
@@ -26,7 +26,7 @@ import useSpeedValidation from '../hooks/useSpeedValidation';
 import useWalkingPattern from '../hooks/useWalkingPattern';
 import useInactivityTimeout from '../hooks/useInactivityTimeout';
 import { useActivityFlags } from '../context/ActivityContext';
-import { requestBiometricValidation } from '../services/antiCheat';
+import { validateBiometricsEnd, validateBiometricsStart } from '../utils/biometrics';
 
 import { usePendingActivities } from '../context/PendingActivitiesContext';
 
@@ -89,7 +89,7 @@ export default function Activity() {
   const handleEndActivity = async () => {
     if (activityEnded) return;
 
-    const ok = await requestBiometricValidation();
+    const ok = await validateBiometricsEnd();
     if (!ok) {
       setFlag('biometricsRejected', true);
       Alert.alert('Biometría requerida');
@@ -188,9 +188,10 @@ export default function Activity() {
     checkInitial();
 
     const init = async () => {
-      const ok = await requestBiometricValidation();
+      const ok = await validateBiometricsStart();
       if (!ok) {
         setFlag('biometricsRejected', true);
+        Alert.alert('Biometría requerida');
         navigation.goBack();
         return;
       }

--- a/utils/biometrics.ts
+++ b/utils/biometrics.ts
@@ -1,0 +1,23 @@
+import * as LocalAuthentication from 'expo-local-authentication';
+
+export async function validateBiometricsStart(): Promise<boolean> {
+  const compatible = await LocalAuthentication.hasHardwareAsync();
+  const enrolled = await LocalAuthentication.isEnrolledAsync();
+  if (!compatible || !enrolled) return false;
+
+  const result = await LocalAuthentication.authenticateAsync({
+    promptMessage: 'Verific\u00E1 tu identidad para comenzar',
+    fallbackLabel: 'Usar c\u00F3digo',
+  });
+
+  return result.success;
+}
+
+export async function validateBiometricsEnd(): Promise<boolean> {
+  const result = await LocalAuthentication.authenticateAsync({
+    promptMessage: 'Verific\u00E1 tu identidad para finalizar',
+    fallbackLabel: 'Usar c\u00F3digo',
+  });
+
+  return result.success;
+}


### PR DESCRIPTION
## Summary
- add real biometric utilities using expo-local-authentication
- require biometric verification when starting and ending an activity

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687122bc80cc8322a810197017dffc08