### PR TITLE
Implement admin claim handling

### DIFF
--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,6 +1,6 @@
 // hooks/useUser.ts
 import { useEffect, useState } from 'react';
-import { onAuthStateChanged, User } from 'firebase/auth';
+import { onAuthStateChanged, User, getIdTokenResult, getIdToken } from 'firebase/auth';
 import { auth } from '../firebase/firebase';
 import { log } from '../utils/logger';
 
@@ -8,10 +8,11 @@ export function useUser() {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [authInitialized, setAuthInitialized] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     log('hooks/useUser.ts', 'useUser', 'AUTH', 'Registrando listener de auth...');
-    const unsub = onAuthStateChanged(auth, (firebaseUser) => {
+    const unsub = onAuthStateChanged(auth, async (firebaseUser) => {
       log(
         'hooks/useUser.ts',
         'onAuthStateChanged',
@@ -21,6 +22,20 @@ export function useUser() {
       setUser(firebaseUser);
       setLoading(false);
       setAuthInitialized(true);
+
+      if (firebaseUser) {
+        await getIdToken(firebaseUser, true);
+        const tokenResult = await getIdTokenResult(firebaseUser);
+        log(
+          'hooks/useUser.ts',
+          'onAuthStateChanged',
+          'AUTH',
+          `[AUTH] Custom claims actualizados: ${JSON.stringify(tokenResult.claims)}`,
+        );
+        setIsAdmin(tokenResult.claims.admin === true);
+      } else {
+        setIsAdmin(false);
+      }
     });
 
     return () => {
@@ -28,5 +43,5 @@ export function useUser() {
     };
   }, []);
 
-  return { user, loading, authInitialized };
+  return { user, loading, authInitialized, isAdmin };
 }


### PR DESCRIPTION
## Summary
- refresh token and store `admin` custom claim in user hook

## Testing
- `npx prettier --write hooks/useUser.ts`
- `npx eslint hooks/useUser.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68719215564c83228abad40d761bb962