### PR TITLE
Improve admin claim flow

### DIFF
--- a/functions/grantAdminRole.js
+++ b/functions/grantAdminRole.js
@@ -1,26 +1,29 @@
 const functions = require('firebase-functions');
-const admin = require('firebase-admin');
+const admin = require('./firebaseAdmin');
 const logger = require('firebase-functions/logger');
 
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
-
-exports.grantAdminRole = functions.https.onRequest(async (req, res) => {
+const handler = async (data, context) => {
   const ADMIN_EMAIL = process.env.ADMIN_EMAIL;
+
+  if (!context.auth || context.auth.token.admin !== true) {
+    logger.warn('Unauthorized attempt to grant admin role');
+    throw new functions.https.HttpsError('permission-denied', 'Only admins can call this function');
+  }
 
   if (!ADMIN_EMAIL) {
     logger.error('ADMIN_EMAIL not set');
-    return res.status(500).send('ADMIN_EMAIL not set in env');
+    throw new functions.https.HttpsError('failed-precondition', 'ADMIN_EMAIL not set in env');
   }
 
   try {
     const user = await admin.auth().getUserByEmail(ADMIN_EMAIL);
     await admin.auth().setCustomUserClaims(user.uid, { admin: true });
     logger.info(`Admin role granted to ${ADMIN_EMAIL}`);
-    res.status(200).send(`Admin role granted to ${ADMIN_EMAIL}`);
+    return { message: `Admin role granted to ${ADMIN_EMAIL}` };
   } catch (err) {
     logger.error('Error granting admin role', err);
-    res.status(500).send('Error granting admin role');
+    throw new functions.https.HttpsError('internal', 'Error granting admin role');
   }
-});
+};
+
+exports.grantAdminRole = functions.https.onCall(handler);

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,2 +1,7 @@
 const { grantAdminRole } = require('./grantAdminRole');
-exports.grantAdminRole = grantAdminRole;
+const { saveActivity } = require('./saveActivity');
+
+module.exports = {
+  grantAdminRole,
+  saveActivity,
+};

--- a/functions/saveActivity.js
+++ b/functions/saveActivity.js
@@ -1,9 +1,11 @@
 const functions = require('firebase-functions');
-const admin = require('./firebase');
+const admin = require('./firebaseAdmin');
 const db = admin.firestore();
 
 function log(file, method, tag, message) {
-  console.log(`\n-------------------- (${file} > ${method}) --------------------\n[${tag}] ${message}\n-----------------------------------------------------------------------\n`);
+  console.log(
+    `\n-------------------- (${file} > ${method}) --------------------\n[${tag}] ${message}\n-----------------------------------------------------------------------\n`,
+  );
 }
 
 exports.saveActivity = functions.https.onRequest(async (req, res) => {
@@ -22,7 +24,7 @@ exports.saveActivity = functions.https.onRequest(async (req, res) => {
     metodoGuardado,
     velocidadPromedio,
     conexion,
-    aceleracionPromedio
+    aceleracionPromedio,
   } = req.body;
 
   if (!userId || !date || distance == null || duration == null) {

--- a/hooks/useAdmin.ts
+++ b/hooks/useAdmin.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { onIdTokenChanged, getIdTokenResult } from 'firebase/auth';
+import { auth } from '../firebase/firebase';
+
+export default function useAdmin() {
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    const unsub = onIdTokenChanged(auth, async (user) => {
+      if (user) {
+        const res = await getIdTokenResult(user, true);
+        setIsAdmin(res.claims.admin === true);
+      } else {
+        setIsAdmin(false);
+      }
+    });
+    return unsub;
+  }, []);
+
+  return isAdmin;
+}

--- a/screens/AdminPanel.tsx
+++ b/screens/AdminPanel.tsx
@@ -15,7 +15,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { useTranslation } from 'react-i18next';
 import { useUser } from '../hooks/useUser';
-import { findUserByEmail, isAdminUser } from '../services/userService';
+import { findUserByEmail, isCurrentUserAdmin } from '../services/userService';
 import { getUserActivitiesSummary, MonthlySummary } from '../services/activityService';
 
 export default function AdminPanel() {
@@ -33,7 +33,7 @@ export default function AdminPanel() {
     const verifyRole = async () => {
       if (user) {
         try {
-          const admin = await isAdminUser(user);
+          const admin = await isCurrentUserAdmin();
           setIsAdmin(admin);
           if (!admin) {
             console.log('AdminPanel: acceso denegado, redirigiendo a Home');
@@ -137,7 +137,9 @@ export default function AdminPanel() {
           onPress={handleSearch}
           style={{ backgroundColor: theme.colors.primary, padding: 12, borderRadius: 6 }}
         >
-          <Text style={{ color: theme.colors.white, textAlign: 'center' }}>{t('admin.search')}</Text>
+          <Text style={{ color: theme.colors.white, textAlign: 'center' }}>
+            {t('admin.search')}
+          </Text>
         </TouchableOpacity>
       </View>
       {loading ? (
@@ -155,9 +157,15 @@ export default function AdminPanel() {
               }}
             >
               <Text style={{ fontWeight: 'bold', color: theme.colors.text }}>{item.month}</Text>
-              <Text style={{ color: theme.colors.text }}>{t('admin.activities', { count: item.totalActivities })}</Text>
-              <Text style={{ color: theme.colors.text }}>{t('admin.distance', { distance: item.totalDistance })}</Text>
-              <Text style={{ color: theme.colors.text }}>{t('admin.time', { time: formatTime(item.totalTime) })}</Text>
+              <Text style={{ color: theme.colors.text }}>
+                {t('admin.activities', { count: item.totalActivities })}
+              </Text>
+              <Text style={{ color: theme.colors.text }}>
+                {t('admin.distance', { distance: item.totalDistance })}
+              </Text>
+              <Text style={{ color: theme.colors.text }}>
+                {t('admin.time', { time: formatTime(item.totalTime) })}
+              </Text>
             </View>
           )}
         />

--- a/screens/Splash.tsx
+++ b/screens/Splash.tsx
@@ -3,7 +3,7 @@ import { Text, StyleSheet, TouchableOpacity, SafeAreaView } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useAppTheme } from '../hooks/useAppTheme';
 import { useUser } from '../hooks/useUser';
-import { isAdminUser } from '../services/userService';
+import { isCurrentUserAdmin } from '../services/userService';
 import { useTranslation } from 'react-i18next';
 
 export default function SplashScreen() {
@@ -18,7 +18,7 @@ export default function SplashScreen() {
       if (!authInitialized) return;
       if (user) {
         try {
-          const admin = await isAdminUser(user);
+          const admin = await isCurrentUserAdmin();
           if (admin) {
             console.log('SplashScreen: redirigiendo a AdminPanel');
             navigation.reset({ index: 0, routes: [{ name: 'AdminPanel' }] });

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -1,5 +1,6 @@
 import { collection, query, where, getDocs, doc, getDoc } from 'firebase/firestore';
 import { getIdTokenResult, User } from 'firebase/auth';
+import { auth } from '../firebase/firebase';
 import db from '../firebase/db';
 
 export const findUserByEmail = async (email: string) => {
@@ -24,4 +25,10 @@ export const isAdminUser = async (currentUser: User): Promise<boolean> => {
   const isAdmin = tokenResult.claims?.admin === true;
   console.log(`isAdminUser: admin -> ${isAdmin}`);
   return isAdmin;
+};
+
+export const isCurrentUserAdmin = async (): Promise<boolean> => {
+  const currentUser = auth.currentUser;
+  if (!currentUser) return false;
+  return isAdminUser(currentUser);
 };


### PR DESCRIPTION
## Summary
- secure the grantAdminRole function and switch to onCall
- expose saveActivity via functions index
- fix Firebase admin import
- refresh admin role checks in screens and user service
- provide `useAdmin` hook

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68725dc0bf5483228261ff2f33901008