### PR TITLE
Fix admin routing with token claim

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,7 +25,7 @@ const Stack = createNativeStackNavigator();
 export default function App() {
   useGlobalNetwork();
   useActivitySync();
-  const { user, loading, authInitialized } = useUser();
+  const { user, loading, authInitialized, isAdmin } = useUser();
 
   if (!authInitialized) {
     log('App.tsx', 'App', 'AUTH', 'Esperando autenticación...');
@@ -36,7 +36,10 @@ export default function App() {
     );
   }
 
-  const initialRoute = user ? 'MainTabs' : 'Splash';
+  let initialRoute = 'Splash';
+  if (user) {
+    initialRoute = isAdmin ? 'AdminPanel' : 'MainTabs';
+  }
   log('App.tsx', 'App', 'APP', `Ruta inicial seleccionada: ${initialRoute}`);
 
   if (loading) {
@@ -55,6 +58,7 @@ export default function App() {
             <KmProvider>
               <NavigationContainer>
                 <Stack.Navigator
+                  key={initialRoute}
                   initialRouteName={initialRoute}
                   screenOptions={{
                     headerShown: false,

--- a/hooks/useAdminStatus.ts
+++ b/hooks/useAdminStatus.ts
@@ -2,14 +2,19 @@ import { useEffect, useState } from 'react';
 import { onIdTokenChanged, getIdTokenResult } from 'firebase/auth';
 import { auth } from '../firebase/firebase';
 
-export default function useAdmin() {
-  const [isAdmin, setIsAdmin] = useState(false);
+export default function useAdminStatus() {
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
 
   useEffect(() => {
     const unsub = onIdTokenChanged(auth, async (user) => {
       if (user) {
-        const res = await getIdTokenResult(user, true);
-        setIsAdmin(res.claims.admin === true);
+        try {
+          const res = await getIdTokenResult(user, true);
+          setIsAdmin(res.claims.admin === true);
+        } catch (err) {
+          console.log('[useAdminStatus] Error fetching token:', err);
+          setIsAdmin(false);
+        }
       } else {
         setIsAdmin(false);
       }

--- a/screens/Login.tsx
+++ b/screens/Login.tsx
@@ -25,15 +25,16 @@ export default function Login({ navigation }: any) {
   const [loading, setLoading] = useState(false);
   const theme = useAppTheme();
   const { theme: mode } = useTheme();
-  const { user } = useUser();
+  const { user, isAdmin } = useUser();
   const { t } = useTranslation();
   const styles = createStyles(theme, mode);
 
   useEffect(() => {
     if (user) {
-      navigation.reset({ index: 0, routes: [{ name: 'MainTabs' }] });
+      const target = isAdmin ? 'AdminPanel' : 'MainTabs';
+      navigation.reset({ index: 0, routes: [{ name: target }] });
     }
-  }, [user]);
+  }, [user, isAdmin]);
 
   const handleLogin = async () => {
     if (!email || !password) {
@@ -57,7 +58,6 @@ export default function Login({ navigation }: any) {
     try {
       setLoading(true);
       await loginWithEmail(email, password);
-      navigation.replace('MainTabs');
     } catch (error: any) {
       if (error.code === 'auth/user-not-found') {
         Alert.alert(t('login.userNotFound'));

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -2,8 +2,11 @@
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from 'firebase/auth';
 import { auth } from '../firebase/firebase';
 
-export const loginWithEmail = (email: string, password: string) =>
-  signInWithEmailAndPassword(auth, email, password);
+export const loginWithEmail = async (email: string, password: string) => {
+  const credential = await signInWithEmailAndPassword(auth, email, password);
+  await credential.user.getIdToken(true);
+  return credential;
+};
 
 export const registerWithEmail = (email: string, password: string) =>
   createUserWithEmailAndPassword(auth, email, password);


### PR DESCRIPTION
## Summary
- add useAdminStatus hook to track custom claim
- refresh token when signing in
- show AdminPanel when admin is logged in
- navigate after login based on admin role

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872615f30488322b82512fdbb88feaf